### PR TITLE
fix tolerance on diffik test

### DIFF
--- a/manipulation/exercises/pick/test_differential_ik.py
+++ b/manipulation/exercises/pick/test_differential_ik.py
@@ -157,7 +157,7 @@ class TestDifferentialIK(unittest.TestCase):
             f_eval.append(f(J_G_lst[i], V_G_desired, None, None, None))
         f_eval = np.array(f_eval).squeeze()
 
-        self.assertLessEqual(np.linalg.norm(f_target - np.stack(f_eval)), 1e-6,
+        self.assertLessEqual(np.linalg.norm(f_target - np.stack(f_eval)), 1e-3,
                              'DiffIKQP input-output response is not correct')
 
     @weight(6)
@@ -311,7 +311,7 @@ class TestDifferentialIK(unittest.TestCase):
             f_eval.append(f(J_G_lst[i], V_G_desired, None, None, p_now_lst[i]))
         f_eval = np.array(f_eval).squeeze()
 
-        self.assertLessEqual(np.linalg.norm(f_target - np.stack(f_eval)), 2e-5,
+        self.assertLessEqual(np.linalg.norm(f_target - np.stack(f_eval)), 1e-3,
                              'DiffIKQP_Wall implementation is not correct.')
 
         # 2. Check that it cannot find solutions when it shouldn't.


### PR DESCRIPTION
Turns out some people wrote the constraint in the unit of velocity instead of position, and that was enough to screw with the numerics of the solver and break the tight tolerance on the testing code. 

This fix relaxes the tolerance so that both answers are accepted (Still pretty low)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/37)
<!-- Reviewable:end -->
