### PR TITLE
Chapter 4 Test Fixes

### DIFF
--- a/manipulation/exercises/pose/test_ransac.py
+++ b/manipulation/exercises/pose/test_ransac.py
@@ -2,7 +2,7 @@ import unittest
 import timeout_decorator
 from gradescope_utils.autograder_utils.decorators import weight
 import numpy as np
-from pydrake.all import RigidTransform, RotationMatrix
+from pydrake.all import (RigidTransform, RotationMatrix, RandomGenerator)
 from sklearn.neighbors import NearestNeighbors
 from copy import deepcopy
 
@@ -28,8 +28,12 @@ def ransac_solution(point_cloud,
 
     point_cloud_1 = np.ones((N, 4))
     point_cloud_1[:, :3] = point_cloud
+
+    generator = RandomGenerator(5)
+
     for i in range(max_iterations):
-        s = point_cloud[np.random.randint(N, size=sample_size)]
+        s = point_cloud[np.random.RandomState(generator()).randint(
+            N, size=sample_size)]
         m = model_fit_func(s)
         abs_distances = np.abs(np.dot(m, point_cloud_1.T))  # 1 x N
         inliner_count = np.sum(abs_distances < tolerance)


### PR DESCRIPTION
@mfeng9 for the record, here are the bugs that were in the previous test:
- Students would sometimes see tests succeeding and failing at random for ransac and icp. RANSAC is really random, so I've added `np.random.seed` to make the test more deterministic (always a good practice for testing that includes random)
- The ICP had a more interesting testing bug. If students forget to handle improper rotations, the following happens:
   - since the test cases written for `least_squares_transform` are based on proper rigid transforms, it never checks for handling of improper rotations. 
   - but this does matter for `icp` since there correspondences are not one-to-one and improper transforms occur. So they would get full score on `least_squares_transforms` but get points off for `icp`.  
   - There are a few lucky cases where even if they didn't handle improper rotations, they luck out and get full score for both. Again, I've added `np.random.seed` to avoid these random luck-outs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/48)
<!-- Reviewable:end -->
