### PR TITLE
setup_manipulation_colab: Remove hack for continuous builds

### DIFF
--- a/scripts/setup/setup_manipulation_colab.py
+++ b/scripts/setup/setup_manipulation_colab.py
@@ -6,16 +6,11 @@ from urllib.request import urlretrieve
 
 
 def setup_drake(*, version, build):
-    if build == "continuous":  # This is a hack!
-        urlretrieve(
-            f"https://drake-packages.csail.mit.edu/drake/nightly/drake-20200915/setup_drake_colab.py",
-            "setup_drake_colab.py")
-    else:
-        urlretrieve(
-            f"https://drake-packages.csail.mit.edu/drake/{build}/drake-{version}/setup_drake_colab.py",
-            "setup_drake_colab.py")
-    from setup_drake_colab import setup_drake
-    setup_drake(version=version, build=build)
+    urlretrieve(
+        f"https://drake-packages.csail.mit.edu/drake/{build}/drake-{version}/setup_drake_colab.py",
+        "setup_drake_colab.py")
+    import setup_drake_colab
+    setup_drake_colab.setup_drake(version=version, build=build)
 
 
 def setup_manipulation(*, manipulation_sha, drake_version, drake_build):


### PR DESCRIPTION
Scope nested `setup_drake` to imported module; otherwise, looks
like confusing recursion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/82)
<!-- Reviewable:end -->
