### PR TITLE
change simulation duration

### DIFF
--- a/exercises/trajectories/door_opening.ipynb
+++ b/exercises/trajectories/door_opening.ipynb
@@ -423,7 +423,9 @@
    },
    "outputs": [],
    "source": [
-    "simulator.AdvanceTo(11.0 if running_as_notebook else 0.1)"
+    "simulator.AdvanceTo(0.1)\n",
+    "# Uncomment and run the simulation to 11 seconds for results.\n",
+    "#simulator.AdvanceTo(11.0)"
    ]
   },
   {


### PR DESCRIPTION
Gradescope is an instance of `not running_as_notebook`, so it won't simulate the trajectory in full.

The test times out, but it's not clear how to have a flag of "not running as notebook but running in gradescope".

Currently my solution is to have the students manually uncomment the line that simulates for 11 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/103)
<!-- Reviewable:end -->
