### PR TITLE
Fix tutorials link based on binder update

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -421,7 +421,7 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
       <ol>
         <li>Check out the growing list of <drake></drake> <a
-        href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials"
+        href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials&urlpath=/tree/ "
         target="_tutorials">tutorials</a> (linked from the main Drake page). In
         the <code>dynamical_systems</code> tutorial, to what value is the
         initial condition, $x(0)$, set when we simulate the


### PR DESCRIPTION
Due to a binder update, the tutorials link was broken. The fix is: 

> Any repos with custom Dockerfiles that  don’t install JupyterLab may start to see a 404 on the default or  filepath URL. They will need to either install jupyterlab or use  urlpath=/tree/ to select the old interface."
> https://discourse.jupyter.org/t/mybinder-org-using-jupyterlab-by-default/10715

So this commit just adds the "urlpath=/tree/" to the tutorials link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/154)
<!-- Reviewable:end -->
