### PR TITLE
Temporary Resolution to clearOutput Error

### DIFF
--- a/manipulation/exercises/grader.py
+++ b/manipulation/exercises/grader.py
@@ -57,11 +57,12 @@ class Grader:
         ipynb = json.load(open(notebook_ipynb))
 
         for cell in ipynb['cells']:
-            #For now, clearOutputs is unsupported, so we filter out those lines
+            # For now, clearOutputs is unsupported, so we filter out those lines
             if ('outputs' in cell.keys()):
-                if any('clearOutput' in line['output_type'] for line in cell['outputs']):
+                if any('clearOutput' in line['output_type']
+                       for line in cell['outputs']):
                     cell['outputs'] = []
-            
+
             # erase test cells, this is optional and useful for debugging
             # to avoid recursions when developing
             if any('## TEST ##' in line for line in cell['source']):

--- a/manipulation/exercises/grader.py
+++ b/manipulation/exercises/grader.py
@@ -57,6 +57,11 @@ class Grader:
         ipynb = json.load(open(notebook_ipynb))
 
         for cell in ipynb['cells']:
+            #For now, clearOutputs is unsupported, so we filter out those lines
+            if ('outputs' in cell.keys()):
+                if any('clearOutput' in line['output_type'] for line in cell['outputs']):
+                    cell['outputs'] = []
+            
             # erase test cells, this is optional and useful for debugging
             # to avoid recursions when developing
             if any('## TEST ##' in line for line in cell['source']):

--- a/manipulation/exercises/grader.py
+++ b/manipulation/exercises/grader.py
@@ -57,7 +57,9 @@ class Grader:
         ipynb = json.load(open(notebook_ipynb))
 
         for cell in ipynb['cells']:
-            # For now, clearOutputs is unsupported, so we filter out those lines
+            # clearOutput as an output type is not supported
+            # by nbformat.reads(). Therefore, filter out
+            # any output cells with the clearOutput warning
             if ('outputs' in cell.keys()):
                 if any('clearOutput' in line['output_type']
                        for line in cell['outputs']):


### PR DESCRIPTION
This is a hack to filter out lines with "clearOutput" when parsing the notebook. Currently, "clearOutput" is not a recognized type by the notebook parser and thus fails on these lines. This hack is a particularly inelegant solution, but would work as a temporary patch for Homework 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/185)
<!-- Reviewable:end -->
