### PR TITLE
minor changes in bunny icp instructions and fixed deepnote links in p…

### DIFF
--- a/exercises/pose/bunny_icp.ipynb
+++ b/exercises/pose/bunny_icp.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "$$\\begin{aligned} \\min_{p\\in\\mathbb{R}^3,R\\in\\mathbb{R}^{3\\times3}} \\quad & \\sum_{i=1}^{N_s} \\| p + R \\hspace{.1cm} {^Op^{m_{c_i}}} - p^{s_i}\\|^2, \\\\ s.t. \\quad & RR^T = I, \\quad \\det(R)=1\\end{aligned}$$\n",
     "    \n",
-    "The goal is to find the transform that registers the point clouds of the model and the scene, assuming the correspondence is known.  You may refer to the implementation from [colab](https://colab.research.google.com/github/RussTedrake/manipulation/blob/master/pose.ipynb#scrollTo=AHfxMwrvb1mz) and the explanation from [textbook](http://manipulation.csail.mit.edu/pose.html#section4).\n",
+    "The goal is to find the transform that registers the point clouds of the model and the scene, assuming the correspondence is known.  You may refer to the implementation from [deepnote](https://deepnote.com/workspace/Manipulation-ac8201a1-470a-4c77-afd0-2cc45bc229ff/project/4-Geometric-Pose-Estimation-cc6340f5-374e-449a-a195-839a3cedec4a/%2Ficp.ipynb) and the explanation from [textbook](http://manipulation.csail.mit.edu/pose.html#section4).\n",
     "\n",
     "In the cell below, implement the ```least_squares_transform``` nethod."
    ]
@@ -146,7 +146,7 @@
     "## Point correspondence from closest point\n",
     "The ```least_squares_transform``` function assumes that the point correspondence is known. Unfortunately, this is often not the case, so we will have to estimate the point correspondence as well. A common heuristics for estimating point correspondence is the closest point/nearest neighbor. \n",
     "\n",
-    "We have implemented the closest neighbors using [Open3d's implementation](http://www.open3d.org/docs/release/python_api/open3d.geometry.KDTreeFlann.html), which uses [k-d trees](https://en.wikipedia.org/wiki/K-d_tree)."
+    "We have implemented the closest neighbors using [scipy's implementation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.KDTree.html) of [k-d trees](https://en.wikipedia.org/wiki/K-d_tree)."
    ]
   },
   {
@@ -321,7 +321,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/pose.html
+++ b/pose.html
@@ -166,7 +166,7 @@ output_ports:
 
       <example class="drake"><h1>Simulating an RGB-D camera</h1>
 
-        <script>document.write(notebook_link('pose'))</script>
+        <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="camera_sim"))</script>
 
         <p>As a simple example of depth cameras in drake, I've constructed a
         scene with a single object (the mustard bottle from the <a
@@ -639,7 +639,7 @@ output_ports:
       will recover the exact solution.  So every one of those steps before
       convergence has at least a few bad correspondences.  Look closely!</p>
   
-      <script>document.write(notebook_link('pose'))</script>
+      <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="icp"))</script>
   
     </example>      
       
@@ -679,7 +679,7 @@ output_ports:
       point), to add noise, and/or to restrict the points to a partial view.
       Please try them by themselves and in combination.</p>
 
-      <script>document.write(notebook_link('pose'))</script>
+      <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="icp"))</script>
   
       <figure style="margin-top:-40px;">
         <iframe style="border:0;height:300px;width:400px;" src="data/icp_outliers.html?height=240px" pdf="no"></iframe>
@@ -1125,7 +1125,7 @@ output_ports:
       <code>AddConstraint</code> methods. I've provided an implementation in
       this notebook: </p>
   
-      <script>document.write(notebook_link('pose'))</script>
+      <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="icp"))</script>
         
       <figure style="margin-top:-20px"><img style="width:70%"
       src="data/constrained_nonlinear_pose.svg"/><figcaption>The solution to
@@ -1163,7 +1163,7 @@ output_ports:
       (SOCP), though we need to use a slack variable to put it into the standard
       form with a linear objective.</p>
 
-      <script>document.write(notebook_link('pose'))</script>
+      <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="icp"))</script>
       
       <p>Please be careful.  Now that we have a constraint that depends on $p$,
       our original approach to solving for $R$ independently is no longer valid
@@ -1240,7 +1240,7 @@ output_ports:
     last chapter to pick it up and place it in the second bin.  Finally, I use
     differential inverse kinematics to execute it.  Very satisfying!</p>
 
-    <script>document.write(notebook_link('pose'))</script>
+    <script>document.write(notebook_link('pose', d=deepnote, link_text="", notebook="pose"))</script>
 
   </section>
   


### PR DESCRIPTION
…ose chapter

The deepnote links that were there in the pose chapter were all linking to the "pose.ipynb" in the pose deepnote folder. I believe it's fixed now (I based the syntax in the html on what I saw in some of the other chapters where the links are correct) but maybe double-check. 

Everything else is a minor wording change in the bunny_icp notebook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/201)
<!-- Reviewable:end -->
