### PR TITLE
fix the possibility of student error causing autograder to run out of…

### DIFF
--- a/manipulation/exercises/deep_perception/test_contrastive.py
+++ b/manipulation/exercises/deep_perception/test_contrastive.py
@@ -32,11 +32,11 @@ def gt_don_predict(f, img_a, img_b, u_a):
 def f_factory(rand_array):
 
     def dummy_f(x: np.ndarray):
-        phi = rand_array.copy()[None]
-        phi = np.tile(phi, (len(x), 1, 1, 1))
         if x.ndim == 3:
             print('f takes in image of shape (N, H, W, 3), '
                   'did you forget to add batch dimension?')
+        phi = rand_array.copy()[None]
+        phi = np.tile(phi, (len(x), 1, 1, 1))
         phi[..., 1:4] += x
         return phi
 

--- a/manipulation/exercises/deep_perception/test_contrastive.py
+++ b/manipulation/exercises/deep_perception/test_contrastive.py
@@ -64,7 +64,7 @@ class TestContrastive(unittest.TestCase):
         self._match = np.random.rand(4096, 1) > 0.4
 
     @weight(4)
-    @timeout_decorator.timeout(1.0)
+    @timeout_decorator.timeout(2.0)
     def test_don_loss(self):
         """Testing don_loss"""
         expected_sol = gt_don_loss(self._f,
@@ -91,7 +91,7 @@ class TestContrastive(unittest.TestCase):
             'Computed loss_nonmatches is incorrect')
 
     @weight(4)
-    @timeout_decorator.timeout(1.0)
+    @timeout_decorator.timeout(2.0)
     def test_don_predict(self):
         """Testing don_predict"""
         expected_sol = gt_don_predict(self._f, self._img_a, self._img_b,


### PR DESCRIPTION
After last patch, the warning is no longer in time so student error of passing in a big batch size could cause memory to run out
See https://piazza.com/class/l6s8p2f23ij7bz/post/420

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/216)
<!-- Reviewable:end -->
