### PR TITLE
Pass BaseFields as Fields object

### DIFF
--- a/exercises/pose/pose_estimation_icp.ipynb
+++ b/exercises/pose/pose_estimation_icp.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "def ToPointCloud(xyzs, rgbs=None):\n",
     "    if rgbs:\n",
-    "        cloud = PointCloud(xyzs.shape[1], BaseField.kXYZs | BaseField.kRGBs)\n",
+    "        cloud = PointCloud(xyzs.shape[1], Fields(BaseField.kXYZs | BaseField.kRGBs))\n",
     "        cloud.mutable_rgbs()[:] = rgbs\n",
     "    else:\n",
     "        cloud = PointCloud(xyzs.shape[1])\n",


### PR DESCRIPTION
PointCloud requires second argument to be of type Fields. Otherwise it raises TypeError:

`TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. pydrake.perception.PointCloud(new_size: int = 0, fields: pydrake.perception.Fields = Fields(base_fields=2))
    2. pydrake.perception.PointCloud(other: pydrake.perception.PointCloud)
`

Instantiate Fields from BaseFields for rgb visualization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russtedrake/manipulation/228)
<!-- Reviewable:end -->
