### PR TITLE
Fix broken image link for ABB Yumi.

### DIFF
--- a/robot.html
+++ b/robot.html
@@ -140,7 +140,7 @@ href="https://www.youtube.com/channel/UChfUOAhz7ynELF-s_1LPpWg">Lecture  videos 
 
       <figure>
         <img width="35%" src="https://www.robots.com/images/robots/Universal/Universal_UR10_0002.jpg" />
-        <img width="55%" src="https://www07.abb.com/api/ir/getimage/36fb710b-54e0-4e53-8383-aacde553ec56/1" />
+        <img width="55%" src="https://webshop.robotics.abb.com/media/catalog/product/d/u/dual_arm_yumi_14000_main.jpg" />
         <figcaption>Two popular position controlled manipulators.  (Left) The UR10 from Universal Robotics.  (Right)The ABB Yumi.</figcaption>
       </figure>
 


### PR DESCRIPTION
The image for the ABB Yumi robot is currently pointing to a [broken link](https://www07.abb.com/api/ir/getimage/36fb710b-54e0-4e53-8383-aacde553ec56/1). I've updated the link to [this](https://webshop.robotics.abb.com/media/catalog/product/d/u/dual_arm_yumi_14000_main.jpg), which matches the previous image (as seen from the [wayback machine](https://web.archive.org/web/20190415034543/https://www07.abb.com/api/ir/getimage/36fb710b-54e0-4e53-8383-aacde553ec56/1)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/236)
<!-- Reviewable:end -->
