### PR TITLE
Fix deepnote link for exercise 2.2.

### DIFF
--- a/robot.html
+++ b/robot.html
@@ -979,7 +979,7 @@ output_ports:
 
     <exercise><h1>Input and Output Ports on the Manipulation Station</h1>
 
-      <p> For this exercise you will investigate how a manipulation station is abstracted in Drake's system-level framework. You will work exclusively in <script>document.write(notebook_link('robot', d=deepnote, link_text='this notebook', notebook='02_manipulation_station_io'))</script>. You will be asked to complete the following steps: </p>
+      <p> For this exercise you will investigate how a manipulation station is abstracted in Drake's system-level framework. You will work exclusively in <script>document.write(notebook_link('robot', d=deepnote, link_text='this notebook', notebook='02_hardware_station_io'))</script>. You will be asked to complete the following steps: </p>
 
       <ol type="a">
         <li> Learn how to probe into inputs and output ports of the manipulation station and evaluate their contents.


### PR DESCRIPTION
The link currently points to the old notebook (that uses manipulation station). This updates it to point to the hardware station notebook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/245)
<!-- Reviewable:end -->
