### PR TITLE
PR2 Transmission Fix

### DIFF
--- a/manipulation/models/pr2_collision_fixed.urdf
+++ b/manipulation/models/pr2_collision_fixed.urdf
@@ -1923,10 +1923,10 @@
     <actuator name="r_wrist_flex_motor"/>
     <joint name="r_wrist_flex_joint"/>
   </transmission>
-  <!-- <transmission name="r_wrist_roll_trans" type="SimpleTransmission">
+  <transmission name="r_wrist_roll_trans" type="SimpleTransmission">
     <actuator name="r_wrist_roll_motor"/>
     <joint name="r_wrist_roll_joint"/>
-  </transmission> -->
+  </transmission>
   <joint name="r_gripper_palm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="r_wrist_roll_link"/>
@@ -2822,10 +2822,10 @@
     <actuator name="l_wrist_flex_motor"/>
     <joint name="l_wrist_flex_joint"/>
   </transmission>
-  <!-- <transmission name="l_wrist_roll_trans" type="SimpleTransmission">
+  <transmission name="l_wrist_roll_trans" type="SimpleTransmission">
     <actuator name="l_wrist_roll_motor"/>
     <joint name="l_wrist_roll_joint"/>
-  </transmission> -->
+  </transmission>
   <joint name="l_gripper_palm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <parent link="l_wrist_roll_link"/>


### PR DESCRIPTION
Two of the PR2 transmissions were commented out in the urdf, making inverse dynamics controller unhappy. This fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/270)
<!-- Reviewable:end -->
