### PR TITLE
Soften Drake dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4523,4 +4523,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "<4.0,>=3.10"
-content-hash = "49d9d17e96a2f178104c43346cdf82fc95cc7fdf9ce0fdabe6509110b24561e0"
+content-hash = "5fee9ca6b8ff2e341b36b3f43a4834152e72eeb8ec4855487b8089aa7896beba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional = true
 
 # Must include all dependencies required to build the docs with sphinx + autodoc.
 [tool.poetry.group.docs.dependencies]
-drake = { version = "==0.0.20240302", source = "drake-nightly" }
+drake = { version = ">=0.0.20240302", source = "drake-nightly" }
 #drake = ">=1.24.0"
 ipython = ">=7.8.0"
 sphinx = ">=7.2.6"


### PR DESCRIPTION
Softening this dependency makes dependency management when `manipulation` is one of the dependencies a lot easier. Moreover, Drake won't break anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/299)
<!-- Reviewable:end -->
