### PR TITLE
Take gains for `InverseDynamicsDriver` as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 This is the companion software for the textbook available at:
 https://manipulation.mit.edu/
 
+For contributions, please see [developer instructions](Developers.md).
+
 To cite this software (or the corresponding textbook), please use:
 
 Russ Tedrake. _Robotic Manipulation: Perception, Planning, and Control (Course

--- a/manipulation/models/spot/spot_with_arm_and_floating_base_actuators.scenario.yaml
+++ b/manipulation/models/spot/spot_with_arm_and_floating_base_actuators.scenario.yaml
@@ -6,7 +6,15 @@ directives:
         arm_sh1: [-3.1]
         arm_el0: [3.1]
 model_drivers:
-    spot: !InverseDynamicsDriver {}
+    spot: !InverseDynamicsDriver
+      gains:
+        arm_sh0: {kp: 1000, ki: 10, kd: 50}
+        arm_sh1: {kp: 1000, ki: 10, kd: 50}
+        arm_el0: {kp: 1000, ki: 10, kd: 50}
+        arm_el1: {kp: 1000, ki: 10, kd: 50}
+        arm_wr0: {kp: 1000, ki: 10, kd: 50}
+        arm_wr1: {kp: 1000, ki: 10, kd: 50}
+        arm_f1x: {kp: 3000, ki: 20, kd: 50}
 cameras:
   back:
     X_BC:

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -86,8 +86,9 @@ class JointPidControllerGains:
     """
 
     kp: float = 100  # Position gain
-    ki: float = 1    # Integral gain
-    kd: float = 20   # Velocity gain
+    ki: float = 1  # Integral gain
+    kd: float = 20  # Velocity gain
+
 
 @dc.dataclass
 class InverseDynamicsDriver:
@@ -719,12 +720,15 @@ def _ApplyDriverConfigSim(
         # Check that all actuator names are valid.
         for actuator_name in driver_config.gains.keys():
             if actuator_name not in actuator_names:
-                raise ValueError(f"Actuator '{actuator_name}' not found. Valid names are: {actuator_names}")
+                raise ValueError(
+                    f"Actuator '{actuator_name}' not found. Valid names are: {actuator_names}"
+                )
 
         # Get gains for each joint from the config. Use default gains if it doesn't exist in the config.
-        gains: typing.List[JointPidControllerGains] = [] 
+        default_gains = JointPidControllerGains()
+        gains: typing.List[JointPidControllerGains] = []
         for actuator_name in actuator_names:
-            joint_gains = driver_config.gains.get(actuator_name, JointPidControllerGains())
+            joint_gains = driver_config.gains.get(actuator_name, default_gains)
             gains.append(joint_gains)
 
         controller = builder.AddSystem(

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -76,13 +76,28 @@ from manipulation.utils import ConfigureParser
 
 
 @dc.dataclass
+class JointPidControllerGains:
+    """Defines the Proportional-Integral-Derivative gains for a single joint.
+
+    Args:
+        kp: The proportional gain.
+        ki: The integral gain.
+        kd: The derivative gain.
+    """
+
+    kp: float = 100  # Position gain
+    ki: float = 1    # Integral gain
+    kd: float = 20   # Velocity gain
+
+@dc.dataclass
 class InverseDynamicsDriver:
     """A simulation-only driver that adds the InverseDynamicsController to the
     station and exports the output ports. Multiple model instances can be driven with a
     single controller using `instance_name1+instance_name2` as the key; the output ports
     will be named similarly."""
 
-    # TODO(russt): Support setting the gains.
+    # Must have one element for every (named) actuator in the model_instance.
+    gains: typing.Mapping[str, JointPidControllerGains] = dc.field(default_factory=dict)
 
 
 @dc.dataclass
@@ -694,13 +709,30 @@ def _ApplyDriverConfigSim(
         controller_plant.Finalize()
 
         # Add the controller
-        # TODO(russt): Take the gains as parameters.
+
+        # When using multiple model instances, the model instance name must be prefixed.
+        # The strings should take the form {model_instance_name}_{joint_actuator_name}, as
+        # prescribed by MultiBodyPlant::GetActuatorNames().
+        add_model_instance_prefix = len(model_instance_names) > 1
+        actuator_names = controller_plant.GetActuatorNames(add_model_instance_prefix)
+
+        # Check that all actuator names are valid.
+        for actuator_name in driver_config.gains.keys():
+            if actuator_name not in actuator_names:
+                raise ValueError(f"Actuator '{actuator_name}' not found. Valid names are: {actuator_names}")
+
+        # Get gains for each joint from the config. Use default gains if it doesn't exist in the config.
+        gains: typing.List[JointPidControllerGains] = [] 
+        for actuator_name in actuator_names:
+            joint_gains = driver_config.gains.get(actuator_name, JointPidControllerGains())
+            gains.append(joint_gains)
+
         controller = builder.AddSystem(
             InverseDynamicsController(
                 controller_plant,
-                kp=[100] * controller_plant.num_positions(),
-                ki=[1] * controller_plant.num_positions(),
-                kd=[20] * controller_plant.num_positions(),
+                kp=[joint_gains.kp for joint_gains in gains],
+                ki=[joint_gains.ki for joint_gains in gains],
+                kd=[joint_gains.kd for joint_gains in gains],
                 has_reference_acceleration=False,
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "manipulation"
 # Use e.g. 2023.10.4.rc0 if I need to release a release candidate.
 # Use e.g. 2023.10.4.post1 if I need to rerelease on the same day.
-version = "2024.04.22"
+version = "2024.05.18"
 description = "MIT 6.421 - Robotic Manipulation"
 authors = ["Russ Tedrake <russt@mit.edu>"]
 license = "BSD License"


### PR DESCRIPTION
### Problem
- Currently, the PID gains of the `InverseDynamicsController` are fixed to a certain default (kp=100, ki=1, kd=20).
- Taking the PID gains as parameters is marked as a TODO item.

### Solution
- This PR implements taking parameters of the `InverseDynamicsDriver` as parameters.
- This is specified by the user as a mapping from the names of the actuator joins to the PID gains, like so:
   ```yaml
   model_drivers:
    spot: !InverseDynamicsDriver
      gains:
        arm_sh0: {kp: 1000, ki: 10, kd: 50}
        arm_sh1: {kp: 1000, ki: 10, kd: 50}
        arm_el0: {kp: 1000, ki: 10, kd: 50}
        arm_el1: {kp: 1000, ki: 10, kd: 50}
        arm_wr0: {kp: 1000, ki: 10, kd: 50}
        arm_wr1: {kp: 1000, ki: 10, kd: 50}
        arm_f1x: {kp: 3000, ki: 20, kd: 50}
   ```

### Backward compatibility
The user is allowed to set the gains of any _subset_ of actuators. Any unspecified actuators will use the default gains. Therefore, existing scenario files that use the `InverseDynamicsDriver` without specifying gains will continue using the defaults for all actuators.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/312)
<!-- Reviewable:end -->
