### PR TITLE
`IiwaDriver`: Create controller MBP from scenario file

### DIFF
--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -55,6 +55,7 @@ from pydrake.all import (
     Parser,
     PdControllerGains,
     ProcessModelDirectives,
+    RigidTransform,
     RobotDiagram,
     RobotDiagramBuilder,
     SceneGraph,
@@ -67,6 +68,7 @@ from pydrake.all import (
     SimIiwaDriver,
     SimulatorConfig,
     VisualizationConfig,
+    WeldJoint,
     ZeroForceDriver,
     position_enabled,
     torque_enabled,
@@ -389,10 +391,14 @@ def _FreezeChildren(
 
     # Remove non-weld joints and replace them with weld joints.
     for joint in joints_to_freeze:
-        frame_on_parent = joint.frame_on_parent()
-        frame_on_child = joint.frame_on_child()
+        weld = WeldJoint(
+            joint.name(),
+            joint.frame_on_parent(),
+            joint.frame_on_child(),
+            RigidTransform(),
+        )
         plant.RemoveJoint(joint)
-        plant.WeldFrames(frame_on_parent, frame_on_child)
+        plant.AddJoint(weld)
 
 
 def _PopulatePlantOrDiagram(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "manipulation"
 # Use e.g. 2023.10.4.rc0 if I need to release a release candidate.
 # Use e.g. 2023.10.4.post1 if I need to rerelease on the same day.
-version = "2024.05.27"
+version = "2024.06.07"
 description = "MIT 6.421 - Robotic Manipulation"
 authors = ["Russ Tedrake <russt@mit.edu>"]
 license = "BSD License"


### PR DESCRIPTION
Fixes #316 

- Create the controller plant for the `IiwaDriver` by reusing the user-provided scenario, instead of creating a custom iiwa (hardcoded to iiwa7) and the WSG schunk.
- This is enabled by being able to freeze child instances i.e. removing non-weld joints in the child instance and replacing them with weld joints. This is in-turn made possible by this recently landed PR: (https://github.com/RobotLocomotion/drake/pull/21397)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/317)
<!-- Reviewable:end -->
