### PR TITLE
Support `add_frame` directives when adding frozen children

### DIFF
--- a/manipulation/BUILD.bazel
+++ b/manipulation/BUILD.bazel
@@ -53,11 +53,22 @@ rt_py_library(
 )
 
 rt_py_library(
+    name = "directives_tree",
+    deps = [
+      "//manipulation",
+    ],
+    srcs = ["directives_tree.py"],
+    imports = [".."],
+    visibility = ["//visibility:public"],
+)
+
+rt_py_library(
     name = "station",
     deps = [
       "//manipulation",
       "scenarios",
       "systems",
+      "directives_tree",
     ],
     srcs = ["station.py"],
     imports = [".."],

--- a/manipulation/BUILD.bazel
+++ b/manipulation/BUILD.bazel
@@ -144,6 +144,14 @@ rt_py_test(
 )
 
 rt_py_test(
+    name = "test_directives_tree",
+    srcs = ["test/test_directives_tree.py"],
+    data = ["//manipulation:station"],
+    imports = [".."],
+    deps = ["manipulation"],
+)
+
+rt_py_test(
     name = "test_utils",
     srcs = ["test/test_utils.py"],
     imports = [".."],

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -1,5 +1,5 @@
 import dataclasses as dc
-from typing import Dict, List, Literal, Set
+from typing import Dict, List, Literal, Set, Tuple
 
 from pydrake.all import AddFrame, AddWeld, ModelDirective, ScopedName
 
@@ -87,3 +87,13 @@ class DirectivesTree:
             f"Node {name} not found in the tree. It neither corresponds to a ",
             f"frame [{self.frame_names}] nor a model instance [{self.model_names}].",
         )
+
+    def GetWeldedChildrenAndDirectives(
+        self, model_instance_names: List[str]
+    ) -> Tuple[List[str], List[ModelDirective]]:
+        pass
+
+    def GetWeldToWorldDirectives(
+        self, model_instance_names: List[str]
+    ) -> List[ModelDirective]:
+        pass

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -40,11 +40,11 @@ class DirectivesTree:
         self.flattened_directives = flattened_directives
         self.add_model_directives: typing.Dict[str, ModelDirective] = dict()
 
-        # Names of frames added by `add_frame` directives
+        # Names of frames added by `add_frame` directives.
         # The default "world" frame exists implicitly.
         self.frame_names: typing.Set[str] = {"world"}
 
-        # Names of models added by `add_model` directives
+        # Names of models added by `add_model` directives.
         self.model_names: typing.Set[str] = set()
 
         # Mapping from parent nodes to the set of its outgoing edges.
@@ -79,11 +79,11 @@ class DirectivesTree:
                     self.edges[parent].add(edge)
 
     def _MakeNode(self, name: str):
-        # Check if this is an added frame
+        # Check if this is an added frame.
         if name in self.frame_names:
             return Node(name, "frame")
 
-        # Check if this corresponds to an added model
+        # Check if this corresponds to an added model.
         model_name = ScopedName.Parse(name).get_namespace()
         if model_name in self.model_names:
             return Node(model_name, "model")
@@ -122,8 +122,7 @@ class DirectivesTree:
                     _descendants.add(edge.child.name)
                     _directives.add(self.add_model_directives[edge.child.name])
 
-                # If the child node has non-zero descendants, add the
-                # edge directive that leads to the child node.
+                # If the child node has non-zero descendants, add the edge directive that leads to the child node.
                 if len(_descendants) > 0:
                     directives.add(edge.directive)
 
@@ -168,8 +167,7 @@ class DirectivesTree:
             for edge in self.edges.get(node, set()):
                 _directives = _RecursionCall(edge.child)
 
-                # If the child node has non-zero directives, add the
-                # edge directive that leads to the child node.
+                # If the child node has non-zero directives, add the edge directive that leads to the child node.
                 if len(_directives) > 0:
                     directives.add(edge.directive)
 

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -22,13 +22,13 @@ DirectivesTree: A set of `add_weld` and `add_frame` directives induces a tree.
 """
 
 
-@dc.dataclass
+@dc.dataclass(frozen=True)
 class Node:
     name: str
     type: Literal["frame", "model"]
 
 
-@dc.dataclass
+@dc.dataclass(frozen=True)
 class Edge:
     parent: Node
     child: Node

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -132,8 +132,9 @@ class DirectivesTree:
                 # If the child is a model instance, add its AddModel directive,
                 # and add its model's name to the set of descendants.
                 if edge.child.type == "model":
-                    _descendants.add(edge.child.name)
-                    _directives.add(self.add_model_directives[edge.child.name])
+                    child_model_name = edge.child.name
+                    _descendants.add(child_model_name)
+                    _directives.add(self.add_model_directives[child_model_name])
 
                 # If the child node has non-zero descendants, add the edge
                 # directive that leads to the child node.

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -88,8 +88,8 @@ class DirectivesTree:
             return Node(model_name, "model")
 
         raise ValueError(
-            f"Node {name} not found in the tree. It neither corresponds to a ",
-            f"frame [{self.frame_names}] nor a model instance [{self.model_names}].",
+            f"Node {name} not found in the tree. It neither corresponds to a "
+            + f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
 
     def GetWeldedDescendantsAndDirectives(

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -122,7 +122,8 @@ class DirectivesTree:
                     _descendants.add(edge.child.name)
                     _directives.add(self.add_model_directives[edge.child.name])
 
-                # If the child node has non-zero descendants, add the edge directive that leads to the child node.
+                # If the child node has non-zero descendants, add the edge
+                # directive that leads to the child node.
                 if len(_descendants) > 0:
                     directives.add(edge.directive)
 
@@ -167,7 +168,8 @@ class DirectivesTree:
             for edge in self.edges.get(node, set()):
                 _directives = _RecursionCall(edge.child)
 
-                # If the child node has non-zero directives, add the edge directive that leads to the child node.
+                # If the child node has non-zero directives, add the edge
+                # directive that leads to the child node.
                 if len(_directives) > 0:
                     directives.add(edge.directive)
 

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -74,7 +74,7 @@ class DirectivesTree:
                 child_name = d.add_frame.name
                 self._AddEdge(parent_name, child_name, d)
 
-    def _MakeNode(self, name: str):
+    def _MakeNode(self, name: str) -> None:
         # Check if this is an added frame.
         if name in self.frame_names:
             return Node(name, "frame")
@@ -89,7 +89,9 @@ class DirectivesTree:
             f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
 
-    def _AddEdge(self, parent_name: str, child_name: str, directive: ModelDirective):
+    def _AddEdge(
+        self, parent_name: str, child_name: str, directive: ModelDirective
+    ) -> None:
         parent = self._MakeNode(parent_name)
         child = self._MakeNode(child_name)
         edge = Edge(parent, child, directive)

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -184,4 +184,8 @@ class DirectivesTree:
     def TopologicallySortDirectives(
         self, directives: typing.Set[ModelDirective]
     ) -> typing.List[ModelDirective]:
+        """
+        This assumes that the flattened directives are in a valid topologically
+        sorted order.
+        """
         return [d for d in self.flattened_directives if d in directives]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -89,7 +89,12 @@ class DirectivesTree:
             + f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
 
-    def _AddEdge(self, parent_name: str, child_name: str, directive: ModelDirective):
+    def _AddEdge(
+        self,
+        parent_name: str,
+        child_name: str,
+        directive: ModelDirective,
+    ) -> typing.NoReturn:
         parent = self._MakeNode(parent_name)
         child = self._MakeNode(child_name)
         edge = Edge(parent, child, directive)

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -3,24 +3,6 @@ import typing
 
 from pydrake.all import ModelDirective, ScopedName
 
-"""
-===============================================================================
-DirectivesTree: A set of `add_weld` and `add_frame` directives induces a tree.
-===============================================================================
-
-• Nodes of the tree
-  -----------------
-    • Each added frame is a node in the tree.
-    • Each model instance (identified by its namespace is a node in the tree).
-
-• Edges of the tree
-  -----------------
-    • Each `add_weld` directive is a directed edge from its parent frame/model
-        to its child frame/model.
-    • Each `add_frame` directive is a directed edge from its base frame/model
-        to its child frame/model.
-"""
-
 
 @dc.dataclass(frozen=True)
 class Node:
@@ -36,6 +18,24 @@ class Edge:
 
 
 class DirectivesTree:
+    """
+    ===========================================================================
+    DirectivesTree: A set of `add_weld` & `add_frame` directives induce a tree
+    ===========================================================================
+
+    • Nodes of the tree
+      -----------------
+        • Each added frame is a node in the tree.
+        • Each model instance (identified by its namespace is a node in the tree).
+
+    • Edges of the tree
+      -----------------
+        • Each `add_weld` directive is a directed edge from its parent
+          frame/model to its child frame/model.
+        • Each `add_frame` directive is a directed edge from its base
+          frame/model to its child frame/model.
+    """
+
     def __init__(self, flattened_directives: typing.List[ModelDirective]):
         self.flattened_directives = flattened_directives
 

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -65,22 +65,14 @@ class DirectivesTree:
         # Create edges.
         for d in self.flattened_directives:
             if d.add_weld:
-                parent = self._MakeNode(d.add_weld.parent)
-                child = self._MakeNode(d.add_weld.child)
-                edge = Edge(parent, child, d)
-                if parent not in self.edges:
-                    self.edges[parent] = {edge}
-                else:
-                    self.edges[parent].add(edge)
+                parent_name = d.add_weld.parent
+                child_name = d.add_weld.child
+                self._AddEdge(parent_name, child_name, d)
 
             if d.add_frame:
-                parent = self._MakeNode(d.add_frame.X_PF.base_frame)
-                child = self._MakeNode(d.add_frame.name)
-                edge = Edge(parent, child, d)
-                if parent not in self.edges:
-                    self.edges[parent] = {edge}
-                else:
-                    self.edges[parent].add(edge)
+                parent_name = d.add_frame.X_PF.base_frame
+                child_name = d.add_frame.name
+                self._AddEdge(parent_name, child_name, d)
 
     def _MakeNode(self, name: str):
         # Check if this is an added frame.
@@ -96,6 +88,15 @@ class DirectivesTree:
             f"Node {name} not found in the tree. It neither corresponds to a "
             + f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
+
+    def _AddEdge(self, parent_name: str, child_name: str, directive: ModelDirective):
+        parent = self._MakeNode(parent_name)
+        child = self._MakeNode(child_name)
+        edge = Edge(parent, child, directive)
+        if parent not in self.edges:
+            self.edges[parent] = {edge}
+        else:
+            self.edges[parent].add(edge)
 
     def GetWeldedDescendantsAndDirectives(
         self, model_instance_names: typing.List[str]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -76,12 +76,12 @@ class DirectivesTree:
     def make_node(self, name: str):
         # Check if this is an added frame
         if name in self.frame_names:
-            return self.Node(name, "frame")
+            return Node(name, "frame")
 
         # Check if this corresponds to an added model
         model_name = ScopedName.Parse(name).get_namespace()
         if model_name in self.model_names:
-            return self.Node(name, "model")
+            return Node(name, "model")
 
         raise ValueError(
             f"Node {name} not found in the tree. It neither corresponds to a ",

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -89,12 +89,7 @@ class DirectivesTree:
             + f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
 
-    def _AddEdge(
-        self,
-        parent_name: str,
-        child_name: str,
-        directive: ModelDirective,
-    ) -> typing.NoReturn:
+    def _AddEdge(self, parent_name: str, child_name: str, directive: ModelDirective):
         parent = self._MakeNode(parent_name)
         child = self._MakeNode(child_name)
         edge = Edge(parent, child, directive)

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -92,7 +92,7 @@ class DirectivesTree:
             f"frame [{self.frame_names}] nor a model instance [{self.model_names}].",
         )
 
-    def GetWeldedChildrenAndDirectives(
+    def GetWeldedDescendantsAndDirectives(
         self, model_instance_names: List[str]
     ) -> Tuple[Set[str], Set[ModelDirective]]:
 
@@ -138,7 +138,8 @@ class DirectivesTree:
             descendants.update(_descendants)
             directives.update(_directives)
 
-        return descendants, directives
+        proper_descendants = descendants - set(model_instance_names)
+        return proper_descendants, directives
 
     def GetWeldToWorldDirectives(
         self, model_instance_names: List[str]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -101,6 +101,14 @@ class DirectivesTree:
     def GetWeldedDescendantsAndDirectives(
         self, model_instance_names: typing.List[str]
     ) -> typing.Tuple[typing.Set[str], typing.List[ModelDirective]]:
+        """
+        Returns:
+            Set[str]: Names of proper descendant models of the input
+                `model_instance_names` in this directives tree.
+            List[ModelDirective]: The directives that need to be added to weld
+                the proper descendant models to the input model instances. The
+                directives list is in a valid topologically sorted order.
+        """
 
         def _RecursiveCall(
             node: Node,
@@ -152,6 +160,14 @@ class DirectivesTree:
     def GetWeldToWorldDirectives(
         self, model_instance_names: typing.List[str]
     ) -> typing.List[ModelDirective]:
+        """
+        Returns:
+            List[ModelDirective]: The directives that need to be added to
+                weld all `model_instance_names` to the "world" frame. This is
+                the minimal set of directives necessary to support all
+                `model_instance_names` in a plant. The directives list is in a
+                valid topologically sorted order.
+        """
 
         def _RecursiveCall(node: Node) -> typing.Set[ModelDirective]:
             """

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -1,0 +1,89 @@
+import dataclasses as dc
+from typing import Dict, List, Literal, Set
+
+from pydrake.all import AddFrame, AddWeld, ModelDirective, ScopedName
+
+"""
+===============================================================================
+DirectivesTree: A set of `add_weld` and `add_frame` directives induces a tree.
+===============================================================================
+
+• Nodes of the tree
+  -----------------
+    • Each added frame is a node in the tree.
+    • Each model instance (identified by its namespace is a node in the tree).
+
+• Edges of the tree
+  -----------------
+    • Each `add_weld` directive is a directed edge from its parent frame/model
+        to its child frame/model.
+    • Each `add_frame` directive is a directed edge from its base frame/model
+        to its child frame/model.
+"""
+
+
+@dc.dataclass
+class Node:
+    name: str
+    type: Literal["frame", "model"]
+
+
+@dc.dataclass
+class Edge:
+    parent: Node
+    child: Node
+    directive: AddWeld | AddFrame
+
+
+class DirectivesTree:
+    def __init__(self, flattened_directives: List[ModelDirective]):
+        # Names of frames added by `add_frame` directives
+        self.frame_names: Set[str] = {}
+
+        # Names of models added by `add_model` directives
+        self.model_names: Set[str] = {}
+
+        # Mapping from parent nodes to the set of its outgoing edges.
+        self.edges: Dict[Node, Set[Edge]] = dict()
+
+        # Read node names.
+        for d in flattened_directives:
+            if d.add_model:
+                self.model_names.add(d.add_model.name)
+            if d.add_frame:
+                self.frame_names.add(d.add_frame.name)
+
+        # Create edges.
+        for d in flattened_directives:
+            if d.add_weld:
+                parent = self.make_node(d.add_weld.parent)
+                child = self.make_node(d.add_weld.child)
+                edge = Edge(parent, child, d.add_weld)
+                if parent not in self.edges:
+                    self.edges[parent] = {edge}
+                else:
+                    self.edges[parent].add(edge)
+
+            if d.add_frame:
+                parent = self.make_node(d.add_frame.X_PF.base_frame)
+                child = self.make_node(d.add_frame.name)
+                edge = Edge(parent, child, d.add_weld)
+                if parent not in self.edges:
+                    self.edges[parent] = {edge}
+                else:
+                    self.edges[parent].add(edge)
+
+    def make_node(self, name: str):
+        # Check if this is an added frame
+        if name in self.frame_names:
+            return self.Node(name, "frame")
+
+        # Check if this corresponds to an added model
+        model_name = ScopedName.Parse(name).get_namespace()
+        if model_name in self.model_names:
+            return self.Node(name, "model")
+
+        raise ValueError(
+            f"Node {name} not found in the tree. It neither corresponds to a ",
+            f"frame [{self.frame_names}] nor a model instance [{self.model_names}].",
+        )

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -97,12 +97,12 @@ class DirectivesTree:
         self, model_instance_names: typing.List[str]
     ) -> typing.Tuple[typing.Set[str], typing.List[ModelDirective]]:
 
-        def _RecursionCall(
+        def _RecursiveCall(
             node: Node,
         ) -> typing.Tuple[typing.Set[str], typing.Set[ModelDirective]]:
             """
             Args:
-                node (Node): The node to start this recursion call from.
+                node (Node): The node to start this recursive call from.
 
             Returns:
                 Set[str]: Names of proper descendant models that are welded to
@@ -114,7 +114,7 @@ class DirectivesTree:
             directives: typing.Set[ModelDirective] = set()
 
             for edge in self.edges.get(node, set()):
-                _descendants, _directives = _RecursionCall(edge.child)
+                _descendants, _directives = _RecursiveCall(edge.child)
 
                 # If the child is a model instance, add its AddModel directive,
                 # and add its model's name to the set of descendants.
@@ -138,7 +138,7 @@ class DirectivesTree:
         for model_instance_name in model_instance_names:
             assert model_instance_name in self.add_model_directives
             node = Node(model_instance_name, "model")
-            _descendants, _directives = _RecursionCall(node)
+            _descendants, _directives = _RecursiveCall(node)
             descendants.update(_descendants)
             directives.update(_directives)
 
@@ -148,10 +148,10 @@ class DirectivesTree:
         self, model_instance_names: typing.List[str]
     ) -> typing.List[ModelDirective]:
 
-        def _RecursionCall(node: Node) -> typing.Set[ModelDirective]:
+        def _RecursiveCall(node: Node) -> typing.Set[ModelDirective]:
             """
             Args:
-                node (Node): The node to start this recursion call from.
+                node (Node): The node to start this recursive call from.
 
             Returns:
                 Set[ModelDirective]: The directives that need to be added to
@@ -166,7 +166,7 @@ class DirectivesTree:
                 return directives
 
             for edge in self.edges.get(node, set()):
-                _directives = _RecursionCall(edge.child)
+                _directives = _RecursiveCall(edge.child)
 
                 # If the child node has non-zero directives, add the edge
                 # directive that leads to the child node.
@@ -179,7 +179,7 @@ class DirectivesTree:
             return directives
 
         world_node = Node("world", "frame")
-        return self.TopologicallySortDirectives(_RecursionCall(world_node))
+        return self.TopologicallySortDirectives(_RecursiveCall(world_node))
 
     def TopologicallySortDirectives(
         self, directives: typing.Set[ModelDirective]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -1,5 +1,5 @@
 import dataclasses as dc
-from typing import Dict, List, Literal, Set, Tuple
+import typing
 
 from pydrake.all import ModelDirective, ScopedName
 
@@ -25,7 +25,7 @@ DirectivesTree: A set of `add_weld` and `add_frame` directives induces a tree.
 @dc.dataclass(frozen=True)
 class Node:
     name: str
-    type: Literal["frame", "model"]
+    type: typing.Literal["frame", "model"]
 
 
 @dc.dataclass(frozen=True)
@@ -36,19 +36,19 @@ class Edge:
 
 
 class DirectivesTree:
-    def __init__(self, flattened_directives: List[ModelDirective]):
+    def __init__(self, flattened_directives: typing.List[ModelDirective]):
         self.flattened_directives = flattened_directives
-        self.add_model_directives: Dict[str, ModelDirective] = dict()
+        self.add_model_directives: typing.Dict[str, ModelDirective] = dict()
 
         # Names of frames added by `add_frame` directives
         # The default "world" frame exists implicitly.
-        self.frame_names: Set[str] = {"world"}
+        self.frame_names: typing.Set[str] = {"world"}
 
         # Names of models added by `add_model` directives
-        self.model_names: Set[str] = set()
+        self.model_names: typing.Set[str] = set()
 
         # Mapping from parent nodes to the set of its outgoing edges.
-        self.edges: Dict[Node, Set[Edge]] = dict()
+        self.edges: typing.Dict[Node, typing.Set[Edge]] = dict()
 
         # Read node names.
         for d in self.flattened_directives:
@@ -94,10 +94,12 @@ class DirectivesTree:
         )
 
     def GetWeldedDescendantsAndDirectives(
-        self, model_instance_names: List[str]
-    ) -> Tuple[Set[str], List[ModelDirective]]:
+        self, model_instance_names: typing.List[str]
+    ) -> typing.Tuple[typing.Set[str], typing.List[ModelDirective]]:
 
-        def _RecursionCall(node: Node) -> Tuple[Set[str], Set[ModelDirective]]:
+        def _RecursionCall(
+            node: Node,
+        ) -> typing.Tuple[typing.Set[str], typing.Set[ModelDirective]]:
             """
             Args:
                 node (Node): The node to start this recursion call from.
@@ -108,8 +110,8 @@ class DirectivesTree:
                 Set[ModelDirective]: The directives that need to be added to
                     weld the proper descendant models to the input node.
             """
-            descendants = set()
-            directives = set()
+            descendants: typing.Set[str] = set()
+            directives: typing.Set[ModelDirective] = set()
 
             for edge in self.edges.get(node, set()):
                 _descendants, _directives = _RecursionCall(edge.child)
@@ -131,8 +133,8 @@ class DirectivesTree:
 
             return descendants, directives
 
-        descendants = set()
-        directives = set()
+        descendants: typing.Set[str] = set()
+        directives: typing.Set[ModelDirective] = set()
         for model_instance_name in model_instance_names:
             assert model_instance_name in self.add_model_directives
             node = Node(model_instance_name, "model")
@@ -143,10 +145,10 @@ class DirectivesTree:
         return descendants, self.TopologicallySortDirectives(directives)
 
     def GetWeldToWorldDirectives(
-        self, model_instance_names: List[str]
-    ) -> List[ModelDirective]:
+        self, model_instance_names: typing.List[str]
+    ) -> typing.List[ModelDirective]:
 
-        def _RecursionCall(node: Node) -> Set[ModelDirective]:
+        def _RecursionCall(node: Node) -> typing.Set[ModelDirective]:
             """
             Args:
                 node (Node): The node to start this recursion call from.
@@ -155,7 +157,7 @@ class DirectivesTree:
                 Set[ModelDirective]: The directives that need to be added to
                     weld all `model_instance_names` to the "world" frame.
             """
-            directives: Set[ModelDirective] = set()
+            directives: typing.Set[ModelDirective] = set()
 
             # Base case: if the node is one of the model instances, add its
             # AddModel directive and return immediately.
@@ -180,6 +182,6 @@ class DirectivesTree:
         return self.TopologicallySortDirectives(_RecursionCall(world_node))
 
     def TopologicallySortDirectives(
-        self, directives: Set[ModelDirective]
-    ) -> List[ModelDirective]:
+        self, directives: typing.Set[ModelDirective]
+    ) -> typing.List[ModelDirective]:
         return [d for d in self.flattened_directives if d in directives]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -1,7 +1,7 @@
 import dataclasses as dc
 from typing import Dict, List, Literal, Set, Tuple
 
-from pydrake.all import AddFrame, AddWeld, ModelDirective, ScopedName
+from pydrake.all import AddFrame, AddModel, AddWeld, ModelDirective, ScopedName
 
 """
 ===============================================================================
@@ -37,8 +37,11 @@ class Edge:
 
 class DirectivesTree:
     def __init__(self, flattened_directives: List[ModelDirective]):
+        self.add_model_directives: Dict[str, AddModel] = dict()
+
         # Names of frames added by `add_frame` directives
-        self.frame_names: Set[str] = {}
+        # The default "world" frame exists implicitly.
+        self.frame_names: Set[str] = {"world"}
 
         # Names of models added by `add_model` directives
         self.model_names: Set[str] = {}
@@ -50,14 +53,15 @@ class DirectivesTree:
         for d in flattened_directives:
             if d.add_model:
                 self.model_names.add(d.add_model.name)
+                self.add_model_directives[d.add_model.name] = d.add_model
             if d.add_frame:
                 self.frame_names.add(d.add_frame.name)
 
         # Create edges.
         for d in flattened_directives:
             if d.add_weld:
-                parent = self.make_node(d.add_weld.parent)
-                child = self.make_node(d.add_weld.child)
+                parent = self._MakeNode(d.add_weld.parent)
+                child = self._MakeNode(d.add_weld.child)
                 edge = Edge(parent, child, d.add_weld)
                 if parent not in self.edges:
                     self.edges[parent] = {edge}
@@ -65,15 +69,15 @@ class DirectivesTree:
                     self.edges[parent].add(edge)
 
             if d.add_frame:
-                parent = self.make_node(d.add_frame.X_PF.base_frame)
-                child = self.make_node(d.add_frame.name)
+                parent = self._MakeNode(d.add_frame.X_PF.base_frame)
+                child = self._MakeNode(d.add_frame.name)
                 edge = Edge(parent, child, d.add_weld)
                 if parent not in self.edges:
                     self.edges[parent] = {edge}
                 else:
                     self.edges[parent].add(edge)
 
-    def make_node(self, name: str):
+    def _MakeNode(self, name: str):
         # Check if this is an added frame
         if name in self.frame_names:
             return Node(name, "frame")
@@ -90,10 +94,84 @@ class DirectivesTree:
 
     def GetWeldedChildrenAndDirectives(
         self, model_instance_names: List[str]
-    ) -> Tuple[List[str], List[ModelDirective]]:
-        pass
+    ) -> Tuple[Set[str], Set[ModelDirective]]:
+
+        def _RecursionCall(node: Node) -> Tuple[Set[str], Set[ModelDirective]]:
+            """
+            Args:
+                node (Node): The node to start this recursion call from.
+
+            Returns:
+                Set[str]: Names of descendant models that are welded to the
+                    input node (including itself).
+                Set[ModelDirective]: The directives that need to be added to
+                    weld the descendant models to the input node.
+            """
+            descendants: Set[str] = {}
+            directives: Set[ModelDirective] = {}
+
+            # if the node is a model instance, add its AddModel directive,
+            # and add the model's name to the set of descendants.
+            if node.type == "model":
+                descendants.add(node.name)
+                directives.add(self.add_model_directives[node.name])
+
+            for edge in self.edges.get(node, set()):
+                # add the descendant and directives of the child node
+                _descendants, _directives = _RecursionCall(edge.child)
+                descendants.update(_descendants)
+                directives.update(_directives)
+
+                # if the child node has non-zero descendants, add the
+                # edge directive that leads to the child node.
+                if len(_descendants) > 0:
+                    directives.add(edge.directive)
+
+            return descendants, directives
+
+        descendants: Set[str] = {}
+        directives: Set[ModelDirective] = {}
+        for model_instance_name in model_instance_names:
+            assert model_instance_name in self.add_model_directives
+            node = Node(model_instance_name, "model")
+            _descendants, _directives = _RecursionCall(node)
+            descendants.update(_descendants)
+            directives.update(_directives)
+
+        return descendants, directives
 
     def GetWeldToWorldDirectives(
         self, model_instance_names: List[str]
-    ) -> List[ModelDirective]:
-        pass
+    ) -> Set[ModelDirective]:
+
+        def _RecursionCall(node: Node) -> Set[ModelDirective]:
+            """
+            Args:
+                node (Node): The node to start this recursion call from.
+
+            Returns:
+                Set[ModelDirective]: The directives that need to be added to
+                    weld all `model_instance_names` to the "world" frame.
+            """
+            directives: Set[ModelDirective] = {}
+
+            # if the node is one of the model instances, add its AddModel
+            # directive and return.
+            if node.type == "model" and node.name in model_instance_names:
+                directives.add(self.add_model_directives[node.name])
+                return directives
+
+            for edge in self.edges.get(node, set()):
+                # add the directives of the child node
+                _directives = _RecursionCall(edge.child)
+                directives.update(_directives)
+
+                # if the child node has non-zero directives, add the
+                # edge directive that leads to the child node.
+                if len(_directives) > 0:
+                    directives.add(edge.directive)
+
+            return directives
+
+        world_node = Node("world", "frame")
+        return _RecursionCall(world_node)

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -37,6 +37,7 @@ class Edge:
 
 class DirectivesTree:
     def __init__(self, flattened_directives: List[ModelDirective]):
+        self.flattened_directives = flattened_directives
         self.add_model_directives: Dict[str, ModelDirective] = dict()
 
         # Names of frames added by `add_frame` directives
@@ -50,7 +51,7 @@ class DirectivesTree:
         self.edges: Dict[Node, Set[Edge]] = dict()
 
         # Read node names.
-        for d in flattened_directives:
+        for d in self.flattened_directives:
             if d.add_model:
                 self.model_names.add(d.add_model.name)
                 self.add_model_directives[d.add_model.name] = d
@@ -58,7 +59,7 @@ class DirectivesTree:
                 self.frame_names.add(d.add_frame.name)
 
         # Create edges.
-        for d in flattened_directives:
+        for d in self.flattened_directives:
             if d.add_weld:
                 parent = self._MakeNode(d.add_weld.parent)
                 child = self._MakeNode(d.add_weld.child)
@@ -176,3 +177,8 @@ class DirectivesTree:
 
         world_node = Node("world", "frame")
         return _RecursionCall(world_node)
+
+    def TopologicallySortDirectives(
+        self, directives: Set[ModelDirective]
+    ) -> List[ModelDirective]:
+        return [d for d in self.flattened_directives if d in directives]

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -86,7 +86,7 @@ class DirectivesTree:
 
         raise ValueError(
             f"Node {name} not found in the tree. It neither corresponds to a "
-            + f"frame {self.frame_names} nor a model instance {self.model_names}."
+            f"frame {self.frame_names} nor a model instance {self.model_names}."
         )
 
     def _AddEdge(self, parent_name: str, child_name: str, directive: ModelDirective):

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -38,6 +38,8 @@ class Edge:
 class DirectivesTree:
     def __init__(self, flattened_directives: typing.List[ModelDirective]):
         self.flattened_directives = flattened_directives
+
+        # Dictionary of all `add_model` directives indexed by the model names.
         self.add_model_directives: typing.Dict[str, ModelDirective] = dict()
 
         # Names of frames added by `add_frame` directives.

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -55,10 +55,12 @@ class DirectivesTree:
         # Read node names.
         for d in self.flattened_directives:
             if d.add_model:
-                self.model_names.add(d.add_model.name)
-                self.add_model_directives[d.add_model.name] = d
+                model_name = d.add_model.name
+                self.model_names.add(model_name)
+                self.add_model_directives[model_name] = d
             if d.add_frame:
-                self.frame_names.add(d.add_frame.name)
+                frame_name = d.add_frame.name
+                self.frame_names.add(frame_name)
 
         # Create edges.
         for d in self.flattened_directives:

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -373,7 +373,7 @@ def _PopulatePlantOrDiagram(
     plant: MultibodyPlant,
     parser: Parser,
     scenario: Scenario,
-    model_instance_names: typing.List[str] = None,
+    model_instance_names: typing.List[str],
     add_frozen_child_instances: bool = True,
     package_xmls: typing.List[str] = [],
     parser_preload_callback: typing.Callable[[Parser], None] = None,
@@ -392,20 +392,15 @@ def _PopulatePlantOrDiagram(
         ModelDirectives(directives=scenario.directives), parser.package_map()
     ).directives
 
-    if model_instance_names is None:
-        # Add all model instances, and hence, all directives.
-        directives = flattened_directives
-        children_to_freeze = set()
-    else:
-        tree = DirectivesTree(flattened_directives)
-        directives = tree.GetWeldToWorldDirectives(model_instance_names)
-        children_to_freeze = set()
+    tree = DirectivesTree(flattened_directives)
+    directives = tree.GetWeldToWorldDirectives(model_instance_names)
+    children_to_freeze = set()
 
-        if add_frozen_child_instances:
-            children_to_freeze, additional_directives = (
-                tree.GetWeldedDescendantsAndDirectives(model_instance_names)
-            )
-            directives.extend(additional_directives)
+    if add_frozen_child_instances:
+        children_to_freeze, additional_directives = (
+            tree.GetWeldedDescendantsAndDirectives(model_instance_names)
+        )
+        directives.extend(additional_directives)
 
     ProcessModelDirectives(
         directives=ModelDirectives(directives=directives),

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -403,7 +403,7 @@ def _PopulatePlantOrDiagram(
 
         if add_frozen_child_instances:
             children_to_freeze, additional_directives = (
-                tree.GetWeldedChildrenAndDirectives(model_instance_names)
+                tree.GetWeldedDescendantsAndDirectives(model_instance_names)
             )
             directives.update(additional_directives)
 

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -405,12 +405,10 @@ def _PopulatePlantOrDiagram(
             children_to_freeze, additional_directives = (
                 tree.GetWeldedDescendantsAndDirectives(model_instance_names)
             )
-            directives.update(additional_directives)
+            directives.extend(additional_directives)
 
     ProcessModelDirectives(
-        directives=ModelDirectives(
-            directives=tree.TopologicallySortDirectives(directives)
-        ),
+        directives=ModelDirectives(directives=directives),
         parser=parser,
     )
 

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -75,6 +75,7 @@ from pydrake.all import (
 )
 from pydrake.common.yaml import yaml_load_typed
 
+from manipulation.directives_tree import DirectivesTree
 from manipulation.systems import ExtractPose
 from manipulation.utils import ConfigureParser
 
@@ -327,39 +328,6 @@ def AppendDirectives(
     return scenario
 
 
-def _FindChildren(
-    flattened_directives: typing.List[ModelDirective],
-    model_instance_names: typing.List[str],
-) -> typing.List[str]:
-    """Given a list of model instances, returns model names that are welded (via
-    directives) to any one of those model instances.
-
-    Returns:
-        A list of model names that are welded to any of the given model instances.
-    """
-    tree = dict()
-    children = set()
-    for d in flattened_directives:
-        if d.add_weld:
-            parent = ScopedName.Parse(d.add_weld.parent).get_namespace()
-            child = ScopedName.Parse(d.add_weld.child).get_namespace()
-            if parent not in tree:
-                tree[parent] = {child}
-            else:
-                tree[parent].add(child)
-
-    def add_children(name):
-        if name in tree:
-            for child in tree[name]:
-                children.add(child)
-                add_children(child)
-
-    for name in model_instance_names:
-        add_children(name)
-
-    return children
-
-
 def _FreezeChildren(
     plant: MultibodyPlant,
     children_to_freeze: typing.List[str],
@@ -423,30 +391,24 @@ def _PopulatePlantOrDiagram(
     flattened_directives = FlattenModelDirectives(
         ModelDirectives(directives=scenario.directives), parser.package_map()
     ).directives
-    children_to_freeze = set()
-    if model_instance_names and add_frozen_child_instances:
-        children_to_freeze = _FindChildren(flattened_directives, model_instance_names)
-    all_model_instances = children_to_freeze.union(model_instance_names)
 
-    directives = []
-    for d in flattened_directives:
-        if d.add_model and (d.add_model.name in all_model_instances):
-            directives.append(d)
-        if (
-            d.add_weld
-            and (
-                ScopedName.Parse(d.add_weld.child).get_namespace()
-                in all_model_instances
+    if model_instance_names is None:
+        # Add all model instances, and hence, all directives.
+        directives = flattened_directives
+        children_to_freeze = set()
+    else:
+        tree = DirectivesTree(flattened_directives)
+        directives = tree.GetWeldToWorldDirectives(model_instance_names)
+        children_to_freeze = set()
+
+        if add_frozen_child_instances:
+            children_to_freeze, additional_directives = (
+                tree.GetWeldedChildrenAndDirectives(model_instance_names)
             )
-            and (
-                d.add_weld.parent == "world"
-                or ScopedName.Parse(d.add_weld.parent).get_namespace()
-                in all_model_instances
-            )
-        ):
-            directives.append(d)
+            directives.update(additional_directives)
+
     ProcessModelDirectives(
-        directives=ModelDirectives(directives=directives),
+        directives=ModelDirectives(directives=list(directives)),
         parser=parser,
     )
 

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -408,7 +408,9 @@ def _PopulatePlantOrDiagram(
             directives.update(additional_directives)
 
     ProcessModelDirectives(
-        directives=ModelDirectives(directives=list(directives)),
+        directives=ModelDirectives(
+            directives=tree.TopologicallySortDirectives(directives)
+        ),
         parser=parser,
     )
 

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -12,6 +12,7 @@ from pydrake.all import (
     Transform,
 )
 
+from manipulation.directives_tree import DirectivesTree
 from manipulation.station import MakeHardwareStation, Scenario
 
 
@@ -100,6 +101,21 @@ class DirectivesTreeTest(unittest.TestCase):
         meshcat = StartMeshcat()
         scenario = self.LoadScenario()
         station = MakeHardwareStation(scenario, meshcat, hardware=False)
+
+    def test_get_welded_descendants_and_directives(self):
+        directives = self.GetFlattenedDirectives()
+        tree = DirectivesTree(directives)
+
+        children, iiwa_directives = tree.GetWeldedDescendantsAndDirectives(["iiwa"])
+        self.assertEqual(children, {"wsg"})
+        self.assertEqual(iiwa_directives, directives[3:6])  # wsg-related directives
+
+    def test_get_weld_to_world_directives(self):
+        directives = self.GetFlattenedDirectives()
+        tree = DirectivesTree(directives)
+
+        iiwa_directives = tree.GetWeldToWorldDirectives(["iiwa"])
+        self.assertEqual(iiwa_directives, directives[:3])  # iiwa-related directives
 
 
 if __name__ == "__main__":

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -8,6 +8,8 @@ from pydrake.all import (
     AddWeld,
     IiwaDriver,
     ModelDirective,
+    MultibodyPlant,
+    RobotDiagram,
     Rotation,
     Transform,
 )
@@ -111,7 +113,15 @@ class DirectivesTreeTest(unittest.TestCase):
                 hand_model_name="wsg",
             )
         }
-        station = MakeHardwareStation(scenario, hardware=False)
+        station: RobotDiagram = MakeHardwareStation(scenario, hardware=False)
+        controller_plant: MultibodyPlant = station.GetSubsystemByName(
+            "iiwa_controller_plant_pointer_system"
+        ).get()
+
+        # Check that the controller plant contains "iiwa" and "wsg" but not "table".
+        self.assertTrue(controller_plant.HasModelInstanceNamed("iiwa"))
+        self.assertTrue(controller_plant.HasModelInstanceNamed("wsg"))
+        self.assertFalse(controller_plant.HasModelInstanceNamed("table"))
 
 
 if __name__ == "__main__":

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -1,69 +1,104 @@
+import typing
 import unittest
 
-from pydrake.all import StartMeshcat
+from pydrake.all import (
+    AddFrame,
+    AddModel,
+    AddWeld,
+    IiwaDriver,
+    ModelDirective,
+    Rotation,
+    StartMeshcat,
+    Transform,
+)
 
-from manipulation.station import LoadScenario, MakeHardwareStation
+from manipulation.station import MakeHardwareStation, Scenario
 
 
 class DirectivesTreeTest(unittest.TestCase):
+    def GetFlattenedDirectives(self) -> typing.List[ModelDirective]:
+        return [
+            ModelDirective(
+                add_model=AddModel(
+                    name="iiwa",
+                    file="package://drake_models/iiwa_description/urdf/iiwa14_no_collision.urdf",
+                )
+            ),
+            ModelDirective(
+                add_frame=AddFrame(
+                    name="iiwa_origin",
+                    X_PF=Transform(
+                        base_frame="world",
+                        translation=[0, 0.765, 0],
+                    ),
+                )
+            ),
+            ModelDirective(
+                add_weld=AddWeld(
+                    parent="iiwa_origin",
+                    child="iiwa::base",
+                )
+            ),
+            ModelDirective(
+                add_model=AddModel(
+                    name="wsg",
+                    file="package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf",
+                )
+            ),
+            ModelDirective(
+                add_frame=AddFrame(
+                    name="iiwa::wsg_attach",
+                    X_PF=Transform(
+                        base_frame="iiwa::iiwa_link_7",
+                        translation=[0, 0, 0.114],
+                        rotation=Rotation.Rpy(deg=[90.0, 0.0, 68.0]),
+                    ),
+                )
+            ),
+            ModelDirective(
+                add_weld=AddWeld(
+                    parent="iiwa::wsg_attach",
+                    child="wsg::body",
+                )
+            ),
+            ModelDirective(
+                add_model=AddModel(
+                    name="table",
+                    file="package://drake_models/manipulation_station/table_wide.sdf",
+                )
+            ),
+            ModelDirective(
+                add_frame=AddFrame(
+                    name="table_origin",
+                    X_PF=Transform(
+                        base_frame="world",
+                        translation=[0.4, 0.3825, 0.0],
+                        rotation=Rotation.Rpy(deg=[0.0, 0.0, 0.0]),
+                    ),
+                )
+            ),
+            ModelDirective(
+                add_weld=AddWeld(
+                    parent="table_origin",
+                    child="table::table_body",
+                )
+            ),
+        ]
+
+    def LoadScenario(self):
+        scenario = Scenario()
+        scenario.directives = self.GetFlattenedDirectives()
+        scenario.model_drivers = {
+            "iiwa": IiwaDriver(
+                control_mode="position_only",
+                hand_model_name="wsg",
+            )
+        }
+        return scenario
+
     def test_load_scenario(self):
-        scenario_data = """
-directives:
-    # Add IIWA
-    - add_model:
-        name: iiwa
-        file: package://drake_models/iiwa_description/urdf/iiwa14_no_collision.urdf
-
-    - add_frame:
-        name: iiwa_origin
-        X_PF:
-            base_frame: world
-            translation: [0, 0.765, 0]
-    
-    - add_weld:
-        parent: iiwa_origin
-        child: iiwa::base
-
-    # Add schunk
-    - add_model:
-        name: wsg
-        file: package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
-
-    - add_frame:
-        name: iiwa::wsg_attach
-        X_PF:
-            base_frame: iiwa::iiwa_link_7
-            translation: [0, 0, 0.114]
-            rotation: !Rpy { deg: [90.0, 0.0, 68.0 ]}
-
-    - add_weld:
-        parent: iiwa::wsg_attach
-        child: wsg::body
-
-    # Add object
-    - add_model:
-        name: table
-        file: package://drake_models/manipulation_station/table_wide.sdf
-
-    - add_frame:
-        name: table_origin
-        X_PF:
-            base_frame: world
-            translation: [0.4, 0.3825, 0.0]
-            rotation: !Rpy { deg: [0., 0., 0.]}
-
-    - add_weld:
-        parent: table_origin
-        child: table::table_body
-    
-model_drivers:
-    iiwa: !IiwaDriver
-        control_mode: position_only
-        hand_model_name: wsg
-"""
-
         meshcat = StartMeshcat()
-        scenario = LoadScenario(data=scenario_data)
+        scenario = self.LoadScenario()
         station = MakeHardwareStation(scenario, meshcat, hardware=False)
 
 

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -89,9 +89,9 @@ class DirectivesTreeTest(unittest.TestCase):
         directives = self.GetFlattenedDirectives()
         tree = DirectivesTree(directives)
 
-        children, iiwa_directives = tree.GetWeldedDescendantsAndDirectives(["iiwa"])
+        children, wsg_directives = tree.GetWeldedDescendantsAndDirectives(["iiwa"])
         self.assertEqual(children, {"wsg"})
-        self.assertEqual(iiwa_directives, directives[3:6])  # wsg-related directives
+        self.assertEqual(wsg_directives, directives[3:6])  # wsg-related directives
 
     def test_get_weld_to_world_directives(self):
         directives = self.GetFlattenedDirectives()

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -1,0 +1,71 @@
+import unittest
+
+from pydrake.all import StartMeshcat
+
+from manipulation.station import LoadScenario, MakeHardwareStation
+
+
+class DirectivesTreeTest(unittest.TestCase):
+    def test_load_scenario(self):
+        scenario_data = """
+directives:
+    # Add IIWA
+    - add_model:
+        name: iiwa
+        file: package://drake_models/iiwa_description/urdf/iiwa14_no_collision.urdf
+
+    - add_frame:
+        name: iiwa_origin
+        X_PF:
+            base_frame: world
+            translation: [0, 0.765, 0]
+    
+    - add_weld:
+        parent: iiwa_origin
+        child: iiwa::base
+
+    # Add schunk
+    - add_model:
+        name: wsg
+        file: package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+
+    - add_frame:
+        name: iiwa::wsg_attach
+        X_PF:
+            base_frame: iiwa::iiwa_link_7
+            translation: [0, 0, 0.114]
+            rotation: !Rpy { deg: [90.0, 0.0, 68.0 ]}
+
+    - add_weld:
+        parent: iiwa::wsg_attach
+        child: wsg::body
+
+    # Add object
+    - add_model:
+        name: table
+        file: package://drake_models/manipulation_station/table_wide.sdf
+
+    - add_frame:
+        name: table_origin
+        X_PF:
+            base_frame: world
+            translation: [0.4, 0.3825, 0.0]
+            rotation: !Rpy { deg: [0., 0., 0.]}
+
+    - add_weld:
+        parent: table_origin
+        child: table::table_body
+    
+model_drivers:
+    iiwa: !IiwaDriver
+        control_mode: position_only
+        hand_model_name: wsg
+"""
+
+        meshcat = StartMeshcat()
+        scenario = LoadScenario(data=scenario_data)
+        station = MakeHardwareStation(scenario, meshcat, hardware=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -16,7 +16,7 @@ from manipulation.station import MakeHardwareStation, Scenario
 
 
 class DirectivesTreeTest(unittest.TestCase):
-    def GetFlattenedDirectives(self) -> typing.List[ModelDirective]:
+    def get_flattened_directives(self) -> typing.List[ModelDirective]:
         return [
             ModelDirective(
                 add_model=AddModel(
@@ -86,7 +86,7 @@ class DirectivesTreeTest(unittest.TestCase):
         ]
 
     def test_get_welded_descendants_and_directives(self):
-        directives = self.GetFlattenedDirectives()
+        directives = self.get_flattened_directives()
         tree = DirectivesTree(directives)
 
         children, wsg_directives = tree.GetWeldedDescendantsAndDirectives(["iiwa"])
@@ -94,7 +94,7 @@ class DirectivesTreeTest(unittest.TestCase):
         self.assertEqual(wsg_directives, directives[3:6])  # wsg-related directives
 
     def test_get_weld_to_world_directives(self):
-        directives = self.GetFlattenedDirectives()
+        directives = self.get_flattened_directives()
         tree = DirectivesTree(directives)
 
         iiwa_directives = tree.GetWeldToWorldDirectives(["iiwa"])
@@ -102,7 +102,7 @@ class DirectivesTreeTest(unittest.TestCase):
 
     def test_load_scenario(self):
         scenario = Scenario()
-        scenario.directives = self.GetFlattenedDirectives()
+        scenario.directives = self.get_flattened_directives()
         scenario.model_drivers = {
             "iiwa": IiwaDriver(
                 control_mode="position_only",

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -1,5 +1,6 @@
 import typing
 import unittest
+from functools import cache
 
 from pydrake.all import (
     AddFrame,
@@ -16,6 +17,7 @@ from manipulation.station import MakeHardwareStation, Scenario
 
 
 class DirectivesTreeTest(unittest.TestCase):
+    @cache
     def get_flattened_directives(self) -> typing.List[ModelDirective]:
         return [
             ModelDirective(

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -8,7 +8,6 @@ from pydrake.all import (
     IiwaDriver,
     ModelDirective,
     Rotation,
-    StartMeshcat,
     Transform,
 )
 
@@ -86,22 +85,6 @@ class DirectivesTreeTest(unittest.TestCase):
             ),
         ]
 
-    def LoadScenario(self):
-        scenario = Scenario()
-        scenario.directives = self.GetFlattenedDirectives()
-        scenario.model_drivers = {
-            "iiwa": IiwaDriver(
-                control_mode="position_only",
-                hand_model_name="wsg",
-            )
-        }
-        return scenario
-
-    def test_load_scenario(self):
-        meshcat = StartMeshcat()
-        scenario = self.LoadScenario()
-        station = MakeHardwareStation(scenario, meshcat, hardware=False)
-
     def test_get_welded_descendants_and_directives(self):
         directives = self.GetFlattenedDirectives()
         tree = DirectivesTree(directives)
@@ -116,6 +99,17 @@ class DirectivesTreeTest(unittest.TestCase):
 
         iiwa_directives = tree.GetWeldToWorldDirectives(["iiwa"])
         self.assertEqual(iiwa_directives, directives[:3])  # iiwa-related directives
+
+    def test_load_scenario(self):
+        scenario = Scenario()
+        scenario.directives = self.GetFlattenedDirectives()
+        scenario.model_drivers = {
+            "iiwa": IiwaDriver(
+                control_mode="position_only",
+                hand_model_name="wsg",
+            )
+        }
+        station = MakeHardwareStation(scenario, hardware=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #322 

## Solution
- [x] Implements a new `DirectivesTree` class in `manipulation/directives_tree.py`. This class creates a tree where:
  - **Nodes:** are defined by _(1)_ model instances and _(2)_ added frames.
  - **Edges:** are defined by _(1)_ `add_weld` and _(2)_ `add_frame` directives.
- [x] The tree implements two recursive search functions:
  - Finding paths from the root ("world" frame) to a given set of robot instances. The use case is to find the minimal set of directives that supports the given robot instances.
  - Finding paths from given robot instances to leaves. The use case is to find child model instances that are welded to the robots (as well as accompanying directives), which is in-turn used to lock the childrens' joints and add their directives to a controller plant.
- [x] This abstraction simplifies the code in `_PopulatePlantOrDiagram()`.

## Unit testing
- [x] Added a test file: `manipulation/test/test_directives_tree.py` that tests the individual search member functions of `DirectivesTree` at the low level and `MakeHardwareStation` at the high-level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/323)
<!-- Reviewable:end -->
