### PR TITLE
Update test_rigid_transforms.py

### DIFF
--- a/manipulation/exercises/pick/test_rigid_transforms.py
+++ b/manipulation/exercises/pick/test_rigid_transforms.py
@@ -69,7 +69,7 @@ class TestRigidTransforms(unittest.TestCase):
         test_X_OG, test_X_WG = f(X_WO)
 
         R_OG = RotationMatrix(np.array([[0, 0, 1], [0, -1, 0], [1, 0, 0]]).T)
-        p_OG = [0, 0.2, 0]
+        p_OG = [0, 0.02, 0]
         X_OG = RigidTransform(R_OG, p_OG)
         X_WG = X_WO.multiply(X_OG)
 


### PR DESCRIPTION
Fixed a typo in the solution. The gripper should be 0.02 units above the object, not 0.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/332)
<!-- Reviewable:end -->
