### PR TITLE
Fix rigid transform test

### DIFF
--- a/manipulation/exercises/pick/test_rigid_transforms.py
+++ b/manipulation/exercises/pick/test_rigid_transforms.py
@@ -69,7 +69,7 @@ class TestRigidTransforms(unittest.TestCase):
         test_X_OG, test_X_WG = f(X_WO)
 
         R_OG = RotationMatrix(np.array([[0, 0, 1], [0, -1, 0], [1, 0, 0]]).T)
-        p_OG = [0, 0.2, 0]
+        p_OG = [0, 0.02, 0]
         X_OG = RigidTransform(R_OG, p_OG)
         X_WG = X_WO.multiply(X_OG)
 


### PR DESCRIPTION
This is necessary for the tests to pass locally for me. I'm not sure why the CI tests passed?

See the associated solutions: https://github.com/RobotLocomotion/manipulation-solutions/commit/819a37a0e82478f88b9ab39affd6abed8d94f999

@qujohn314 @thatprogrammer1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/334)
<!-- Reviewable:end -->
