### PR TITLE
fixed scaling of image for 4.10

### DIFF
--- a/book/clutter.html
+++ b/book/clutter.html
@@ -1415,6 +1415,9 @@ output_ports:
 
       <p>For this exercise, you will investigate a slightly different approach to normal vector estimation. In particular, we can exploit the spatial structure that is already in a depth image to avoid computing nearest neighbors. You will work exclusively in <script>document.write(notebook_link('clutter', notebook='normal_estimation_depth', link_text='this notebook'))</script>. You will be asked to complete the following steps:</p>
       <ol type="a">
+        <li> Analyze mathematically how the data matrix constructed from close
+        clusters of points in a depth image can be used to compute surface normals.
+        </li>
         <li> Implement a method to estimate normal vectors from a depth image,
         without computing nearest neighbors. </li>
         <li> Reason about a scenario where the depth image-based solution will

--- a/book/pose.html
+++ b/book/pose.html
@@ -1597,7 +1597,7 @@ output_ports:
     <p>In the figure below we draw two objects: a shaded red object and a shaded blue object (the purple region is two objects overlapping and the objects should be treated as infinite half planes). Let $\phi_r(p)$ be the signed distance value of a point $p$ to boundary of the red object and $\phi_b(p)$ be the signed distance value of point $p$ to the boundary blue object. As an example $\phi_b(p_0) = -3, \phi_b(p_1) = +2$.</p>
 
     <figure>
-      <img style="width:50%", src="figures/exercises/sdf_compose.png"/>
+      <img style="width:100%", src="figures/exercises/sdf_compose.png"/>
     </figure>
 
     <ol type="a">


### PR DESCRIPTION
- The size of the new image for the modified 4.10 problem was too small. I verified this new sizing locally first and it is now a lot better.

- Updated 5.2 problem description.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/360)
<!-- Reviewable:end -->
