### PR TITLE
Fix GetWeldToWorldDirectives for more than one model instances

### DIFF
--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -183,11 +183,10 @@ class DirectivesTree:
             """
             directives: typing.Set[ModelDirective] = set()
 
-            # Base case: if the node is one of the model instances, add its
-            # AddModel directive and return immediately.
+            # Base case: if the node is one of the model instances, add its AddModel
+            # directive.
             if node.type == "model" and node.name in model_instance_names:
                 directives.add(self.add_model_directives[node.name])
-                return directives
 
             for edge in self.edges.get(node, set()):
                 _directives = _RecursiveCall(edge.child)

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -158,6 +158,9 @@ class DirectivesTree:
             descendants.update(_descendants)
             directives.update(_directives)
 
+        # Don't include the input model instances in the descendants set.
+        descendants.difference_update(model_instance_names)
+
         return descendants, self.TopologicallySortDirectives(directives)
 
     def GetDirectivesFromRootToModels(

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -160,7 +160,7 @@ class DirectivesTree:
 
         return descendants, self.TopologicallySortDirectives(directives)
 
-    def GetWeldToWorldDirectives(
+    def GetDirectivesFromRootToModels(
         self, model_instance_names: typing.List[str]
     ) -> typing.List[ModelDirective]:
         """

--- a/manipulation/directives_tree.py
+++ b/manipulation/directives_tree.py
@@ -102,14 +102,13 @@ class DirectivesTree:
 
     def GetWeldedDescendantsAndDirectives(
         self, model_instance_names: typing.List[str]
-    ) -> typing.Tuple[typing.Set[str], typing.List[ModelDirective]]:
+    ) -> typing.Tuple[typing.Set[str], typing.Set[ModelDirective]]:
         """
         Returns:
             Set[str]: Names of proper descendant models of the input
                 `model_instance_names` in this directives tree.
-            List[ModelDirective]: The directives that need to be added to weld
-                the proper descendant models to the input model instances. The
-                directives list is in a valid topologically sorted order.
+            Set[ModelDirective]: The directives that need to be added to weld
+                the proper descendant models to the input model instances.
         """
 
         def _RecursiveCall(
@@ -161,18 +160,17 @@ class DirectivesTree:
         # Don't include the input model instances in the descendants set.
         descendants.difference_update(model_instance_names)
 
-        return descendants, self.TopologicallySortDirectives(directives)
+        return descendants, directives
 
     def GetDirectivesFromRootToModels(
         self, model_instance_names: typing.List[str]
-    ) -> typing.List[ModelDirective]:
+    ) -> typing.Set[ModelDirective]:
         """
         Returns:
-            List[ModelDirective]: The directives that need to be added to
+            Set[ModelDirective]: The directives that need to be added to
                 weld all `model_instance_names` to the "world" frame. This is
                 the minimal set of directives necessary to support all
-                `model_instance_names` in a plant. The directives list is in a
-                valid topologically sorted order.
+                `model_instance_names` in a plant.
         """
 
         def _RecursiveCall(node: Node) -> typing.Set[ModelDirective]:
@@ -205,7 +203,7 @@ class DirectivesTree:
             return directives
 
         world_node = Node("world", "frame")
-        return self.TopologicallySortDirectives(_RecursiveCall(world_node))
+        return _RecursiveCall(world_node)
 
     def TopologicallySortDirectives(
         self, directives: typing.Set[ModelDirective]

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -401,10 +401,11 @@ def _PopulatePlantOrDiagram(
         children_to_freeze, additional_directives = (
             tree.GetWeldedDescendantsAndDirectives(model_instance_names)
         )
-        directives.extend(additional_directives)
+        directives.update(additional_directives)
 
+    sorted_directives = tree.TopologicallySortDirectives(directives)
     ProcessModelDirectives(
-        directives=ModelDirectives(directives=directives),
+        directives=ModelDirectives(directives=sorted_directives),
         parser=parser,
     )
 

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -394,7 +394,7 @@ def _PopulatePlantOrDiagram(
     ).directives
 
     tree = DirectivesTree(flattened_directives)
-    directives = tree.GetWeldToWorldDirectives(model_instance_names)
+    directives = tree.GetDirectivesFromRootToModels(model_instance_names)
     children_to_freeze = set()
 
     if add_frozen_child_instances:

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -381,6 +381,12 @@ def _PopulatePlantOrDiagram(
     parser_prefinalize_callback: typing.Callable[[Parser], None] = None,
 ) -> None:
     """See MakeMultibodyPlant and MakeRobotDiagram for details."""
+    if model_instance_names is None:
+        assert not add_frozen_child_instances, (
+            "add_frozen_child_instances cannot be used without specifying "
+            "model_instance_names."
+        )
+
     ApplyMultibodyPlantConfig(scenario.plant_config, plant)
     for p in package_xmls:
         parser.package_map().AddPackageXml(p)
@@ -393,17 +399,23 @@ def _PopulatePlantOrDiagram(
         ModelDirectives(directives=scenario.directives), parser.package_map()
     ).directives
 
-    tree = DirectivesTree(flattened_directives)
-    directives = tree.GetDirectivesFromRootToModels(model_instance_names)
-    children_to_freeze = set()
+    if not model_instance_names is None:
+        tree = DirectivesTree(flattened_directives)
+        directives = tree.GetDirectivesFromRootToModels(model_instance_names)
+        children_to_freeze = set()
 
-    if add_frozen_child_instances:
-        children_to_freeze, additional_directives = (
-            tree.GetWeldedDescendantsAndDirectives(model_instance_names)
-        )
-        directives.update(additional_directives)
+        if add_frozen_child_instances:
+            children_to_freeze, additional_directives = (
+                tree.GetWeldedDescendantsAndDirectives(model_instance_names)
+            )
+            directives.update(additional_directives)
 
-    sorted_directives = tree.TopologicallySortDirectives(directives)
+        sorted_directives = tree.TopologicallySortDirectives(directives)
+    else:
+        # Add all model instances.
+        sorted_directives = flattened_directives
+        children_to_freeze = set()
+
     ProcessModelDirectives(
         directives=ModelDirectives(directives=sorted_directives),
         parser=parser,

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -101,10 +101,10 @@ class DirectivesTreeTest(unittest.TestCase):
         directives = self.get_flattened_directives()
         tree = DirectivesTree(directives)
 
-        iiwa_directives = tree.GetWeldToWorldDirectives(["iiwa"])
+        iiwa_directives = tree.GetDirectivesFromRootToModels(["iiwa"])
         self.assertEqual(iiwa_directives, directives[:3])  # iiwa-related directives
 
-        iiwa_wsg_directives = tree.GetWeldToWorldDirectives(["iiwa", "wsg"])
+        iiwa_wsg_directives = tree.GetDirectivesFromRootToModels(["iiwa", "wsg"])
         self.assertEqual(iiwa_wsg_directives, directives[:6])
 
     def test_load_scenario(self):

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -95,17 +95,26 @@ class DirectivesTreeTest(unittest.TestCase):
 
         children, wsg_directives = tree.GetWeldedDescendantsAndDirectives(["iiwa"])
         self.assertEqual(children, {"wsg"})
-        self.assertEqual(wsg_directives, directives[3:6])  # wsg-related directives
+        sorted_wsg_directives = tree.TopologicallySortDirectives(wsg_directives)
+        self.assertEqual(
+            sorted_wsg_directives, directives[3:6]
+        )  # wsg-related directives
 
     def test_get_weld_to_world_directives(self):
         directives = self.get_flattened_directives()
         tree = DirectivesTree(directives)
 
         iiwa_directives = tree.GetDirectivesFromRootToModels(["iiwa"])
-        self.assertEqual(iiwa_directives, directives[:3])  # iiwa-related directives
+        sorted_iiwa_directives = tree.TopologicallySortDirectives(iiwa_directives)
+        self.assertEqual(
+            sorted_iiwa_directives, directives[:3]
+        )  # iiwa-related directives
 
         iiwa_wsg_directives = tree.GetDirectivesFromRootToModels(["iiwa", "wsg"])
-        self.assertEqual(iiwa_wsg_directives, directives[:6])
+        sorted_iiwa_wsg_directives = tree.TopologicallySortDirectives(
+            iiwa_wsg_directives
+        )
+        self.assertEqual(sorted_iiwa_wsg_directives, directives[:6])
 
     def test_load_scenario(self):
         scenario = Scenario()

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -15,7 +15,7 @@ from pydrake.all import (
 )
 
 from manipulation.directives_tree import DirectivesTree
-from manipulation.station import MakeHardwareStation, Scenario
+from manipulation.station import MakeHardwareStation, MakeMultibodyPlant, Scenario
 
 
 class DirectivesTreeTest(unittest.TestCase):
@@ -115,6 +115,38 @@ class DirectivesTreeTest(unittest.TestCase):
             iiwa_wsg_directives
         )
         self.assertEqual(sorted_iiwa_wsg_directives, directives[:6])
+
+    def test_make_multibody_plant(self):
+        scenario = Scenario()
+        scenario.directives = self.get_flattened_directives()
+        scenario.model_drivers = {
+            "iiwa": IiwaDriver(
+                control_mode="position_only",
+                hand_model_name="wsg",
+            )
+        }
+
+        # Test with all model instances.
+        plant: MultibodyPlant = MakeMultibodyPlant(scenario)
+        self.assertTrue(plant.HasModelInstanceNamed("iiwa"))
+        self.assertTrue(plant.HasModelInstanceNamed("wsg"))
+        self.assertTrue(plant.HasModelInstanceNamed("table"))
+
+        # Test with only "iiwa" and "wsg".
+        plant: MultibodyPlant = MakeMultibodyPlant(
+            scenario, model_instance_names=["iiwa", "wsg"]
+        )
+        self.assertTrue(plant.HasModelInstanceNamed("iiwa"))
+        self.assertTrue(plant.HasModelInstanceNamed("wsg"))
+        self.assertFalse(plant.HasModelInstanceNamed("table"))
+
+        # Test with only "iiwa".
+        plant: MultibodyPlant = MakeMultibodyPlant(
+            scenario, model_instance_names=["iiwa"]
+        )
+        self.assertTrue(plant.HasModelInstanceNamed("iiwa"))
+        self.assertFalse(plant.HasModelInstanceNamed("wsg"))
+        self.assertFalse(plant.HasModelInstanceNamed("table"))
 
     def test_load_scenario(self):
         scenario = Scenario()

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -148,6 +148,16 @@ class DirectivesTreeTest(unittest.TestCase):
         self.assertFalse(plant.HasModelInstanceNamed("wsg"))
         self.assertFalse(plant.HasModelInstanceNamed("table"))
 
+        # Test with only "iiwa" and "add_frozen_child_instances=True"
+        plant: MultibodyPlant = MakeMultibodyPlant(
+            scenario,
+            model_instance_names=["iiwa"],
+            add_frozen_child_instances=True,
+        )
+        self.assertTrue(plant.HasModelInstanceNamed("iiwa"))
+        self.assertTrue(plant.HasModelInstanceNamed("wsg"))
+        self.assertFalse(plant.HasModelInstanceNamed("table"))
+
     def test_load_scenario(self):
         scenario = Scenario()
         scenario.directives = self.get_flattened_directives()

--- a/manipulation/test/test_directives_tree.py
+++ b/manipulation/test/test_directives_tree.py
@@ -104,6 +104,9 @@ class DirectivesTreeTest(unittest.TestCase):
         iiwa_directives = tree.GetWeldToWorldDirectives(["iiwa"])
         self.assertEqual(iiwa_directives, directives[:3])  # iiwa-related directives
 
+        iiwa_wsg_directives = tree.GetWeldToWorldDirectives(["iiwa", "wsg"])
+        self.assertEqual(iiwa_wsg_directives, directives[:6])
+
     def test_load_scenario(self):
         scenario = Scenario()
         scenario.directives = self.get_flattened_directives()


### PR DESCRIPTION
The 'return' statement ignored all but the first model instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/370)
<!-- Reviewable:end -->
