### PR TITLE
Increase the segmentation_and_grasp test tolerance

### DIFF
--- a/manipulation/exercises/segmentation/test_segmentation_and_grasp.py
+++ b/manipulation/exercises/segmentation/test_segmentation_and_grasp.py
@@ -61,6 +61,6 @@ class TestSegmentationAndGrasp(unittest.TestCase):
             chamfer_dist(
                 pcd_pts_target[:, :min_num_pts], pcd_pts_eval[:, :min_num_pts]
             ),
-            1e-4,
+            5e-4,
             "Point cloud points are not close enough to the solution values.",
         )


### PR DESCRIPTION
For some reason, the model prediction with the same weights is different on deepnote than on my local computer. We need to increase the tolerance to account for this...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/380)
<!-- Reviewable:end -->
