### PR TITLE
Add "| None" type annotation for args that can be `None`

### DIFF
--- a/manipulation/create_sdf_from_mesh.py
+++ b/manipulation/create_sdf_from_mesh.py
@@ -20,7 +20,7 @@ from lxml import etree as ET
 def calc_mesh_com_and_inertia(
     mesh: trimesh.Trimesh,
     mass: float,
-    frame: np.ndarray = None,
+    frame: np.ndarray | None = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Calculates the mesh's center of mass and moment of inertia by assuming a uniform
     mass density.

--- a/manipulation/meshcat_utils.py
+++ b/manipulation/meshcat_utils.py
@@ -364,7 +364,7 @@ def plot_mathematical_program(
     prog: MathematicalProgram,
     X: np.ndarray,
     Y: np.ndarray,
-    result: MathematicalProgramResult = None,
+    result: MathematicalProgramResult | None = None,
     point_size: float = 0.05,
 ):
     """Visualize a MathematicalProgram in Meshcat.

--- a/manipulation/scenarios.py
+++ b/manipulation/scenarios.py
@@ -506,7 +506,7 @@ def AddMultibodyTriad(frame, scene_graph, length=0.25, radius=0.01, opacity=1.0)
 
 
 def AddIiwaDifferentialIK(
-    builder: DiagramBuilder, plant: MultibodyPlant, frame: Frame = None
+    builder: DiagramBuilder, plant: MultibodyPlant, frame: Frame | None = None
 ) -> DifferentialInverseKinematicsIntegrator:
     warnings.warn(
         "Please use manipulation.systems.AddIiwaDifferentialIK instead.",

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -217,9 +217,9 @@ class Directives:
 
 def load_scenario(
     *,
-    filename: str = None,
-    data: str = None,
-    scenario_name: str = None,
+    filename: str | None = None,
+    data: str | None = None,
+    scenario_name: str | None = None,
     defaults: Scenario = Scenario(),
 ):
     warnings.warn("load_scenario is deprecated. Use LoadScenario instead.")
@@ -230,9 +230,9 @@ def load_scenario(
 
 def add_scenario(
     *,
-    filename: str = None,
-    data: str = None,
-    scenario_name: str = None,
+    filename: str | None = None,
+    data: str | None = None,
+    scenario_name: str | None = None,
     defaults: Scenario = Scenario(),
 ):
     warnings.warn("add_directives is deprecated. Use AppendDirectives instead.")
@@ -244,9 +244,9 @@ def add_scenario(
 # TODO(russt): load from url (using packagemap).
 def LoadScenario(
     *,
-    filename: str = None,
-    data: str = None,
-    scenario_name: str = None,
+    filename: str | None = None,
+    data: str | None = None,
+    scenario_name: str | None = None,
     defaults: Scenario = Scenario(),
 ) -> Scenario:
     """Implements the command-line handling logic for scenario data.
@@ -291,9 +291,9 @@ def LoadScenario(
 def AppendDirectives(
     scenario: Scenario,
     *,
-    filename: str = None,
-    data: str = None,
-    scenario_name: str = None,
+    filename: str | None = None,
+    data: str | None = None,
+    scenario_name: str | None = None,
 ) -> Scenario:
     """Append additional directives to an existing scenario.
 
@@ -374,11 +374,11 @@ def _PopulatePlantOrDiagram(
     plant: MultibodyPlant,
     parser: Parser,
     scenario: Scenario,
-    model_instance_names: typing.List[str],
+    model_instance_names: typing.List[str] | None,
     add_frozen_child_instances: bool = True,
     package_xmls: typing.List[str] = [],
-    parser_preload_callback: typing.Callable[[Parser], None] = None,
-    parser_prefinalize_callback: typing.Callable[[Parser], None] = None,
+    parser_preload_callback: typing.Callable[[Parser], None] | None = None,
+    parser_prefinalize_callback: typing.Callable[[Parser], None] | None = None,
 ) -> None:
     """See MakeMultibodyPlant and MakeRobotDiagram for details."""
     if model_instance_names is None:
@@ -432,11 +432,11 @@ def _PopulatePlantOrDiagram(
 def MakeMultibodyPlant(
     scenario: Scenario,
     *,
-    model_instance_names: typing.List[str] = None,
+    model_instance_names: typing.List[str] | None = None,
     add_frozen_child_instances: bool = False,
     package_xmls: typing.List[str] = [],
-    parser_preload_callback: typing.Callable[[Parser], None] = None,
-    parser_prefinalize_callback: typing.Callable[[Parser], None] = None,
+    parser_preload_callback: typing.Callable[[Parser], None] | None = None,
+    parser_prefinalize_callback: typing.Callable[[Parser], None] | None = None,
 ) -> MultibodyPlant:
     """Use a scenario to create a MultibodyPlant. This is intended, e.g., to facilitate
     easily building subsets of a scenario, for instance, to make a plant for a
@@ -489,11 +489,11 @@ def MakeMultibodyPlant(
 def MakeRobotDiagram(
     scenario: Scenario,
     *,
-    model_instance_names: typing.List[str] = None,
+    model_instance_names: typing.List[str] | None = None,
     add_frozen_child_instances: bool = True,
     package_xmls: typing.List[str] = [],
-    parser_preload_callback: typing.Callable[[Parser], None] = None,
-    parser_prefinalize_callback: typing.Callable[[Parser], None] = None,
+    parser_preload_callback: typing.Callable[[Parser], None] | None = None,
+    parser_prefinalize_callback: typing.Callable[[Parser], None] | None = None,
 ) -> RobotDiagram:
     """Use a scenario to create a RobotDiagram (MultibodyPlant + SceneGraph). This is
     intended, e.g., to facilitate easily building subsets of a scenario, for instance,
@@ -906,13 +906,13 @@ def _ApplyCameraConfigSim(
 
 def MakeHardwareStation(
     scenario: Scenario,
-    meshcat: Meshcat = None,
+    meshcat: Meshcat | None = None,
     *,
     package_xmls: typing.List[str] = [],
     hardware: bool = False,
-    parser_preload_callback: typing.Callable[[Parser], None] = None,
-    parser_prefinalize_callback: typing.Callable[[Parser], None] = None,
-    prebuild_callback: typing.Callable[[DiagramBuilder], None] = None,
+    parser_preload_callback: typing.Callable[[Parser], None] | None = None,
+    parser_prefinalize_callback: typing.Callable[[Parser], None] | None = None,
+    prebuild_callback: typing.Callable[[DiagramBuilder], None] | None = None,
 ) -> Diagram:
     """Make a diagram encapsulating a simulation of (or the communications
     interface to/from) a physical robot, including sensors and controllers.
@@ -1381,7 +1381,7 @@ def _ApplyCameraLcmIdInterface(
 
 def _MakeHardwareStationInterface(
     scenario: Scenario,
-    meshcat: Meshcat = None,
+    meshcat: Meshcat | None = None,
     *,
     package_xmls: typing.List[str] = [],
 ) -> Diagram:
@@ -1462,8 +1462,8 @@ def AddPointClouds(
     scenario: Scenario,
     station: Diagram,
     builder: DiagramBuilder,
-    poses_output_port: OutputPort = None,
-    meshcat: Meshcat = None,
+    poses_output_port: OutputPort | None = None,
+    meshcat: Meshcat | None = None,
 ) -> typing.Mapping[str, DepthImageToPointCloud]:
     """
     Adds one DepthImageToPointCloud system to the `builder` for each camera in `scenario`, and connects it to the respective camera station output ports.

--- a/manipulation/systems.py
+++ b/manipulation/systems.py
@@ -78,7 +78,7 @@ class MultibodyPositionToBodyPose(LeafSystem):
 
 
 def AddIiwaDifferentialIK(
-    builder: DiagramBuilder, plant: MultibodyPlant, frame: Frame = None
+    builder: DiagramBuilder, plant: MultibodyPlant, frame: Frame | None = None
 ) -> DifferentialInverseKinematicsIntegrator:
     """Adds a DifferentialInverseKinematicsIntegrator system to the builder with default parameters suitable for use with the standard 7-link iiwa models or the 3-link planar iiwa models.
 

--- a/manipulation/utils.py
+++ b/manipulation/utils.py
@@ -149,7 +149,7 @@ def DrakeVersionGreaterThan(minimum_date: date):
             )
 
 
-def RenderDiagram(system: System, max_depth: int = None):
+def RenderDiagram(system: System, max_depth: int | None = None):
     """Use pydot to render the GraphViz diagram of the given system.
 
     Args:


### PR DESCRIPTION
Currently, many arguments are annotated as type `Type` (e.g. `Meshcat`) while their default value is set to `None`. This "implicit optional" convention, which was acceptable in the past, is now discouraged by PEP-484 [[1](https://peps.python.org/pep-0484/#union-types)]. It causes my editor to show "unreachable code" warnings since it assumes these arguments cannot be None.

<img src=https://github.com/user-attachments/assets/c53719ba-f09e-47ec-b8e8-58ea1367376b width=80%></img>
<img src=https://github.com/user-attachments/assets/859bdf58-3159-4d62-be5b-4a301f12152b width=80%></img>

This PR fixes the type annotation from `Type` to `Type | None`.

There is an older way to denote `typing.Union[Type, None]`, which is `typing.Optional[Type]`. `Type | None` was introduced in PEP-604. Both are valid. There is no precedent in the manipulation repo, while both have been used in Drake [[2](https://github.com/search?q=repo%3ARobotLocomotion%2Fdrake+%22typing.Optional%22&type=code), [3](https://github.com/search?q=repo%3ARobotLocomotion%2Fdrake+%22%7C+None%22&type=code)].

However, `Type | None` seems to be encouraged by Python developers [[4](https://stackoverflow.com/questions/69440494/python-3-10-optionaltype-or-type-none), [5](https://discuss.python.org/t/clarification-for-pep-604-is-foo-int-none-to-replace-all-use-of-foo-optional-int/26945/6)] over `typing.Optional`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/388)
<!-- Reviewable:end -->
