### PR TITLE
Fix mux/demux in InverseDynamicsDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://manipulation.mit.edu/
 Online code documentation can be found
 [here](https://manipulation.mit.edu/python/index.html).
 
-For contributions, please see [developer instructions](Developers.md).
+For contributions, please see [developer instructions](https://github.com/RussTedrake/htmlbook/blob/master/Developers.md).
 
 To cite this software (or the corresponding textbook), please use:
 

--- a/manipulation/BUILD.bazel
+++ b/manipulation/BUILD.bazel
@@ -173,6 +173,14 @@ rt_py_test(
 )
 
 rt_py_test(
+    name = "test_inverse_dynamics_driver",
+    srcs = ["test/test_inverse_dynamics_driver.py"],
+    data = ["//manipulation:station"],
+    imports = [".."],
+    deps = ["manipulation"],
+)
+
+rt_py_test(
     name = "test_hardware_station_interface",
     srcs = ["test/test_hardware_station_interface.py"],
     data = ["//manipulation:station"],

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -738,11 +738,11 @@ def _ApplyDriverConfigSim(
             )
         else:
             combined_state = builder.AddSystem(
-                _MultiplexState(sim_plant, model_instance_names)
+                _MultiplexState(controller_plant, model_instance_names)
             )
             combined_state.set_name(model_instance_name + ".combined_state")
             combined_input = builder.AddSystem(
-                _DemultiplexActuation(sim_plant, model_instance_names)
+                _DemultiplexActuation(controller_plant, model_instance_names)
             )
             combined_input.set_name(model_instance_name + ".combined_input")
             for index, model_instance in enumerate(model_instances):

--- a/manipulation/station.py
+++ b/manipulation/station.py
@@ -888,7 +888,7 @@ def MakeHardwareStation(
     parser_preload_callback: typing.Callable[[Parser], None] | None = None,
     parser_prefinalize_callback: typing.Callable[[Parser], None] | None = None,
     prebuild_callback: typing.Callable[[DiagramBuilder], None] | None = None,
-) -> Diagram:
+) -> RobotDiagram:
     """Make a diagram encapsulating a simulation of (or the communications
     interface to/from) a physical robot, including sensors and controllers.
 

--- a/manipulation/test/test_inverse_dynamics_driver.py
+++ b/manipulation/test/test_inverse_dynamics_driver.py
@@ -1,0 +1,110 @@
+import unittest
+
+import numpy as np
+from pydrake.all import Simulator
+
+from manipulation.station import LoadScenario, MakeHardwareStation
+
+
+class InverseDynamicsDriverTest(unittest.TestCase):
+    def get_bimanual_directives_data(self):
+        return """
+directives:
+- add_model:
+    name: iiwa_left
+    file: package://drake_models/iiwa_description/urdf/iiwa14_no_collision.urdf
+- add_frame:
+    name: iiwa_left_origin
+    X_PF:
+        base_frame: world
+        translation: [0, 0.765, 0]
+- add_weld:
+    parent: iiwa_left_origin
+    child: iiwa_left::base
+- add_model:
+    name: wsg_left
+    file: package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+- add_frame:
+    name: iiwa_left::wsg_attach
+    X_PF:
+        base_frame: iiwa_left::iiwa_link_7
+        translation: [0, 0, 0.114]
+        rotation: !Rpy { deg: [90, 0, 68]}
+- add_weld:
+    parent: iiwa_left::iiwa_link_7
+    child: wsg_left::body
+    X_PC:
+        translation: [0, 0, 0.09]
+        rotation: !Rpy { deg: [90, 0, 90]}
+- add_model:
+    name: iiwa_right
+    file: package://drake_models/iiwa_description/urdf/iiwa14_no_collision.urdf
+- add_frame:
+    name: iiwa_right_origin
+    X_PF:
+        base_frame: world
+        translation: [0, -0.765, 0]
+- add_weld:
+    parent: iiwa_right_origin
+    child: iiwa_right::base
+- add_model:
+    name: wsg_right
+    file: package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+- add_frame:
+    name: iiwa_right::wsg_attach
+    X_PF:
+        base_frame: iiwa_right::iiwa_link_7
+        translation: [0, 0, 0.114]
+        rotation: !Rpy { deg: [90, 0, 68]}
+- add_weld:
+    parent: iiwa_right::iiwa_link_7
+    child: wsg_right::body
+    X_PC:
+        translation: [0, 0, 0.09]
+        rotation: !Rpy { deg: [90, 0, 90]}
+        """
+
+    def make_controller_test(self, model_name: str, model_dof: int):
+        directives_data = self.get_bimanual_directives_data()
+        model_drivers_data = f"""
+model_drivers:
+    {model_name}: !InverseDynamicsDriver {{}}
+        """
+        scenario = LoadScenario(data=directives_data + model_drivers_data)
+        station = MakeHardwareStation(scenario)
+
+        simulator = Simulator(station)
+        context = simulator.get_mutable_context()
+        fixed_value = np.zeros(2 * model_dof)
+        station.GetInputPort(f"{model_name}.desired_state").FixValue(
+            context, fixed_value
+        )
+        simulator.AdvanceTo(1.0)
+
+    def test_controller_on_single_model(self):
+        self.make_controller_test(
+            model_name="iiwa_left",
+            model_dof=7,
+        )
+
+    def test_controller_on_two_models(self):
+        self.make_controller_test(
+            model_name="iiwa_left+wsg_left",
+            model_dof=9,
+        )
+
+    def test_controller_on_three_models(self):
+        self.make_controller_test(
+            model_name="iiwa_left+wsg_left+iiwa_right",
+            model_dof=16,
+        )
+
+    def test_controller_on_all_models(self):
+        self.make_controller_test(
+            model_name="iiwa_left+iiwa_right+wsg_left+wsg_right",
+            model_dof=18,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `InverseDynamicsDriver` uses `_MultiplexState` and `_DemultiplexActuation` when creating a unified `InverseDynamicsController` for more than one models. This PR fixes two issues:

## Issues

1. Currently, `_MultiplexState` and `_DemultiplexActuation` use the `sim_plant`. This is a problem when the controller plant is created for a strict subset of all actuated models in the plant. Specifically, `_DemultiplexActuation` throws the following error due to a mismatch in the `num_actuated_dofs` of the `sim_plant`, and the sum of the actuated DOFs of `model_instance_names`.
    ```
    File "/home/sancha/repos/manipulation/manipulation/station.py", line 595, in CalcOutput
        self._plant.GetActuationFromArray(model_instance_index, input)
    RuntimeError: Passed in array is not properly sized.
    ```
    **FIX:** The InverseDynamicsController controls a "controller plant", which is a subset of the sim plant. We should use the controller plant to multiplex the state into, and de-multiplex actuation from the controller. This correctly sizes the actuation array.

2. Currently, `_MultiplexState` multiplexes models in the order specified in `model_instance_names`. This is problematic if the order diverges from the order of the model directives.

    **FIX:** Similar to `_plant.GetActuationFromArray()`, we can first retrieve the model_instance_index and use `_plant.SetPositionsInArray()` and `_plant.SetVelocitiesInArray()` to compose the combined state in the correct permutation.

## Tests

I've added `test_inverse_dynamics_driver.py` that creates a scenario with bimanual arms and grippers -- a total of four models. Then, I test the `InverseDynamicsController` on subsets (1, 2, 3, 4) of the models.
- Tests currently fail when using 2, 3 models (passes for a single model since `len(model_instances) == 1` is handled as a special case.
- The PR passes all four tests.