### PR TITLE
requirements: Use latest drake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,16 +41,15 @@ exclude = [
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[[tool.poetry.source]]
-name = "drake-nightly"
-url = "https://drake-packages.csail.mit.edu/whl/nightly/"
-priority = "explicit"
+#[[tool.poetry.source]]
+#name = "drake-nightly"
+#url = "https://drake-packages.csail.mit.edu/whl/nightly/"
+#priority = "explicit"
 
 [tool.poetry.dependencies]
 python = "<4.0,>=3.10"
 cloudpickle = { version="2.2.1", optional=true} # needs to be pinned for stored files to remain compatible.
-drake = { version = ">=0.0.20250131 <0.1", source = "drake-nightly" }
-#drake = ">=1.37.0"
+drake = ">=1.38.0"
 gradescope-utils = { version=">=0.4.0", optional=true}
 gymnasium = { version=">0.26", optional=true }
 ipython = ">=7.8.0" # TODO: make this optional?
@@ -122,8 +121,7 @@ optional = true
 # script uses `poetry install --only docs`. This include any requirements
 # needed to import for a file that sphinx autodoc is trying to index. None of
 # these should be marked as optional.
-drake = { version = ">=0.0.20250118 <0.1", source = "drake-nightly" }
-#drake = ">=1.37.0"
+drake = ">=1.38.0"
 ipython = ">=7.8.0"
 lxml = {version = ">=4.9.2", extras = ["html_clean"] }
 mpld3  = { version=">=0.5.6", optional=false }


### PR DESCRIPTION
Per Slack thread, we encountered an issue due to this constraint and https://github.com/RobotLocomotion/drake/issues/22694

This is one viable workaround, at least for referencing a specific SHA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/446)
<!-- Reviewable:end -->
