### PR TITLE
Fix isort lint CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
       - name: isort
         uses: isort/isort-action@master
         with:
-            configuration: "--profile black"
+            configuration: "--profile black --check-only"
             isort-version: 5.12.0
       - name: autoflake
         uses: creyD/autoflake_action@master


### PR DESCRIPTION
The isort lint CI reported errors that it caught but didn't make the CI fail. This didn't happen in this repo, as we were good at using `pre-commit`. However, I discovered this in a different repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/448)
<!-- Reviewable:end -->
