### PR TITLE
Only run pull_request_target for forked PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,15 @@ jobs:
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+      ||
+      (github.event_name == 'pull_request_target' &&
+       needs.check-approval.outputs.should-run == 'true')
+      ||
+      (github.event_name != 'pull_request' &&
+       github.event_name != 'pull_request_target')
     steps:
       - name: pre-checkout setup
         run: |
@@ -140,7 +148,15 @@ jobs:
     name: macos sonoma 14
     runs-on: macos-14
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+      ||
+      (github.event_name == 'pull_request_target' &&
+       needs.check-approval.outputs.should-run == 'true')
+      ||
+      (github.event_name != 'pull_request' &&
+       github.event_name != 'pull_request_target')
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
       - name: checkout PR code
@@ -177,7 +193,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+      ||
+      (github.event_name == 'pull_request_target' &&
+       needs.check-approval.outputs.should-run == 'true')
+      ||
+      (github.event_name != 'pull_request' &&
+       github.event_name != 'pull_request_target')
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
       - name: checkout PR code
@@ -232,7 +256,17 @@ jobs:
     name: dockerfile
     runs-on: ubuntu-latest
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: >
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
+       ||
+       (github.event_name == 'pull_request_target' &&
+        needs.check-approval.outputs.should-run == 'true')
+       ||
+       (github.event_name != 'pull_request' &&
+        github.event_name != 'pull_request_target'))
+      &&
+      !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: russtedrake/manipulation:latest
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
@@ -281,7 +315,17 @@ jobs:
     name: pip notebooks on noble
     runs-on: ubuntu-24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: >
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
+       ||
+       (github.event_name == 'pull_request_target' &&
+        needs.check-approval.outputs.should-run == 'true')
+       ||
+       (github.event_name != 'pull_request' &&
+        github.event_name != 'pull_request_target'))
+      &&
+      !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: ubuntu:24.04
     steps:
       - name: pre-checkout setup
@@ -336,7 +380,17 @@ jobs:
     name: pip extra on noble
     runs-on: ubuntu-24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: >
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
+       ||
+       (github.event_name == 'pull_request_target' &&
+        needs.check-approval.outputs.should-run == 'true')
+       ||
+       (github.event_name != 'pull_request' &&
+        github.event_name != 'pull_request_target'))
+      &&
+      !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: ubuntu:24.04
     steps:
       - name: pre-checkout setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: pre-checkout setup
         run: |
@@ -140,7 +140,7 @@ jobs:
     name: macos sonoma 14
     runs-on: macos-14
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
       - name: checkout PR code
@@ -177,7 +177,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
       - name: checkout PR code
@@ -232,7 +232,7 @@ jobs:
     name: dockerfile
     runs-on: ubuntu-latest
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: russtedrake/manipulation:latest
     steps:
       # For pull_request_target: carefully checkout PR code excluding .github/
@@ -281,7 +281,7 @@ jobs:
     name: pip notebooks on noble
     runs-on: ubuntu-24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: ubuntu:24.04
     steps:
       - name: pre-checkout setup
@@ -336,7 +336,7 @@ jobs:
     name: pip extra on noble
     runs-on: ubuntu-24.04
     needs: [check-approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
+    if: always() && (github.event_name != 'pull_request_target' || needs.check-approval.outputs.should-run == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.pull_request.labels.*.name, 'requires new pip wheels')
     container: ubuntu:24.04
     steps:
       - name: pre-checkout setup


### PR DESCRIPTION
This PR adds a check on the workflow, and skips the workflow if it is triggered by a `pull_request` from a forked repository (these will always fail, as the workflows triggered by `pull_request` event runs the forked code and does not have access to the repo secrets and can't checkout the notebook solutions). As a result, only the workflows triggered by (approved) `pull_request_target` events run for forked PRs, which is what we want.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/495)
<!-- Reviewable:end -->
