### PR TITLE
fix link to UR3e model in code example

### DIFF
--- a/book/robot/inspector.ipynb
+++ b/book/robot/inspector.ipynb
@@ -86,7 +86,7 @@
     "    elif description == \"Franka Emika Panda\":\n",
     "        return \"package://drake_models/franka_description/urdf/panda_arm_hand.urdf\"\n",
     "    elif description == \"UR3e\":\n",
-    "        return \"package://drake_models/ur_description/ur3e_cylinders_collision.urdf\"\n",
+    "        return \"package://drake_models/ur_description/urdf/ur3e_cylinders_collision.urdf\"\n",
     "    raise Exception(\"Unknown model\")\n",
     "\n",
     "\n",


### PR DESCRIPTION
model file is located in

https://github.com/RobotLocomotion/models/blob/master/ur_description/urdf/ur3e_cylinders_collision.urdf

the `urdf` directory is missing in the notebook code example path, which leads to an error when running the code (when the UR3e arm/model is selected)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/manipulation/565)
<!-- Reviewable:end -->
